### PR TITLE
Remove shutdown from API contract

### DIFF
--- a/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
@@ -31,12 +31,6 @@ public struct InMemoryServiceDiscovery<Service: Hashable, Instance: Hashable>: S
         self.configuration.instancesToExclude
     }
 
-    private let _isShutdown = SDAtomic<Bool>(false)
-
-    public var isShutdown: Bool {
-        self._isShutdown.load()
-    }
-
     public init(configuration: Configuration) {
         self.configuration = configuration
         self.serviceInstances = configuration.serviceInstances
@@ -79,14 +73,10 @@ public struct InMemoryServiceDiscovery<Service: Hashable, Instance: Hashable>: S
         let previousInstances = self.serviceInstances[service]
         self.serviceInstances[service] = instances
 
-        if !self.isShutdown, instances != previousInstances, let subscribers = self.serviceSubscribers[service] {
+        if instances != previousInstances, let subscribers = self.serviceSubscribers[service] {
             // Notify subscribers whenever instances change
             subscribers.forEach { $0(.success(instances)) }
         }
-    }
-
-    public func shutdown() {
-        self._isShutdown.store(true)
     }
 }
 

--- a/Sources/ServiceDiscovery/ServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/ServiceDiscovery.swift
@@ -27,9 +27,6 @@ public protocol ServiceDiscovery {
     /// Instances to exclude from lookup results.
     var instancesToExclude: Set<Instance>? { get }
 
-    /// Indicates if `shutdown` has been issued and therefore all subscriptions are cancelled.
-    var isShutdown: Bool { get }
-
     /// Performs a lookup for the given service's instances. The result will be sent to `callback`.
     ///
     /// `defaultLookupTimeout` will be used to compute `deadline` in case one is not specified.
@@ -40,9 +37,6 @@ public protocol ServiceDiscovery {
     /// The service's current list of instances will be sent to `handler` when this method is first invoked. Subsequently,
     /// `handler` will only receive updates when the `service`'s instances change.
     mutating func subscribe(to service: Service, handler: @escaping (Result<[Instance], Error>) -> Void)
-
-    /// Performs clean up steps if any before shutting down.
-    mutating func shutdown() throws
 }
 
 /// Errors that might occur during lookup.

--- a/Tests/ServiceDiscoveryTests/InMemoryServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/InMemoryServiceDiscoveryTests.swift
@@ -37,7 +37,6 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
         configuration.register(service: barService, instances: barInstances)
 
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
-        defer { serviceDiscovery.shutdown() }
 
         let fooResult = try ensureResult(serviceDiscovery: serviceDiscovery, service: fooService)
         guard case .success(let _fooInstances) = fooResult else {
@@ -59,7 +58,6 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
 
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: ["foo-service": []])
         let serviceDiscovery = InMemoryServiceDiscovery<Service, Instance>(configuration: configuration)
-        defer { serviceDiscovery.shutdown() }
 
         let result = try ensureResult(serviceDiscovery: serviceDiscovery, service: unknownService)
         guard case .failure(let error) = result else {
@@ -84,7 +82,6 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
 
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [fooService: fooInstances])
         var serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
-        defer { serviceDiscovery.shutdown() }
 
         let semaphore = DispatchSemaphore(value: 0)
         let resultCounter = SDAtomic<Int>(0)


### PR DESCRIPTION
Requires https://github.com/apple/swift-service-discovery/pull/6. The actual change is https://github.com/apple/swift-service-discovery/commit/3b4e3380627d8cdc3f81b855c4fa1adc61e0167c

Motivation:
API review feedback

Modifications:
Remove `shutdown` from `ServiceDiscovery` protocol. Let individual backend implementations decide if they need custom shutdown sequence.

Result:
Allow backend implementations more flexibility around how they handle shutdown.