### PR TITLE
Rename subscribe callbacks

### DIFF
--- a/Sources/ServiceDiscovery/ServiceDiscovery+TypeErased.swift
+++ b/Sources/ServiceDiscovery/ServiceDiscovery+TypeErased.swift
@@ -44,8 +44,8 @@ public class ServiceDiscoveryBox<Service: Hashable, Instance: Hashable>: Service
         self._lookup = { service, deadline, callback in
             serviceDiscovery.lookup(service, deadline: deadline, callback: callback)
         }
-        self._subscribe = { service, onNext, onComplete in
-            serviceDiscovery.subscribe(to: service, onNext: onNext, onComplete: onComplete)
+        self._subscribe = { service, nextResultHandler, completionHandler in
+            serviceDiscovery.subscribe(to: service, nextResultHandler: nextResultHandler, completionHandler: completionHandler)
         }
     }
 
@@ -56,10 +56,10 @@ public class ServiceDiscoveryBox<Service: Hashable, Instance: Hashable>: Service
     @discardableResult
     public func subscribe(
         to service: Service,
-        onNext: @escaping (Result<[Instance], Error>) -> Void,
-        onComplete: @escaping (CompletionReason) -> Void = { _ in }
+        nextResultHandler: @escaping (Result<[Instance], Error>) -> Void,
+        completionHandler: @escaping (CompletionReason) -> Void = { _ in }
     ) -> CancellationToken {
-        self._subscribe(service, onNext, onComplete)
+        self._subscribe(service, nextResultHandler, completionHandler)
     }
 
     /// Unwraps the underlying `ServiceDiscovery` instance as `ServiceDiscoveryImpl` type.
@@ -109,14 +109,14 @@ public class AnyServiceDiscovery: ServiceDiscovery {
                 callback(result.map { $0.map(AnyHashable.init) })
             }
         }
-        self._subscribe = { anyService, onNext, onComplete in
+        self._subscribe = { anyService, nextResultHandler, completionHandler in
             guard let service = anyService.base as? ServiceDiscoveryImpl.Service else {
                 preconditionFailure("Expected service type to be \(ServiceDiscoveryImpl.Service.self), got \(type(of: anyService.base))")
             }
             return serviceDiscovery.subscribe(
                 to: service,
-                onNext: { result in onNext(result.map { $0.map(AnyHashable.init) }) },
-                onComplete: onComplete
+                nextResultHandler: { result in nextResultHandler(result.map { $0.map(AnyHashable.init) }) },
+                completionHandler: completionHandler
             )
         }
     }
@@ -147,10 +147,10 @@ public class AnyServiceDiscovery: ServiceDiscovery {
     @discardableResult
     public func subscribe(
         to service: AnyHashable,
-        onNext: @escaping (Result<[AnyHashable], Error>) -> Void,
-        onComplete: @escaping (CompletionReason) -> Void = { _ in }
+        nextResultHandler: @escaping (Result<[AnyHashable], Error>) -> Void,
+        completionHandler: @escaping (CompletionReason) -> Void = { _ in }
     ) -> CancellationToken {
-        self._subscribe(service, onNext, onComplete)
+        self._subscribe(service, nextResultHandler, completionHandler)
     }
 
     /// See `subscribe`.
@@ -159,10 +159,10 @@ public class AnyServiceDiscovery: ServiceDiscovery {
     @discardableResult
     public func subscribeAndUnwrap<Service, Instance>(
         to service: Service,
-        onNext: @escaping (Result<[Instance], Error>) -> Void,
-        onComplete: @escaping (CompletionReason) -> Void = { _ in }
+        nextResultHandler: @escaping (Result<[Instance], Error>) -> Void,
+        completionHandler: @escaping (CompletionReason) -> Void = { _ in }
     ) -> CancellationToken where Service: Hashable, Instance: Hashable {
-        self._subscribe(AnyHashable(service), { result in onNext(self.transform(result)) }, onComplete)
+        self._subscribe(AnyHashable(service), { result in nextResultHandler(self.transform(result)) }, completionHandler)
     }
 
     private func transform<Instance>(_ result: Result<[AnyHashable], Error>) -> Result<[Instance], Error> where Instance: Hashable {

--- a/Tests/ServiceDiscoveryTests/TypeErasedServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/TypeErasedServiceDiscoveryTests.swift
@@ -65,7 +65,7 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
         // Two results are expected:
         // Result #1: LookupError.unknownService because bar-service is not registered
         // Result #2: Later we register bar-service and that should notify the subscriber
-        boxedServiceDiscovery.subscribe(to: self.barService, onNext: { result in
+        boxedServiceDiscovery.subscribe(to: self.barService, nextResultHandler: { result in
             resultCounter.add(1)
 
             guard resultCounter.load() <= 2 else {
@@ -136,7 +136,7 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
         // Two results are expected:
         // Result #1: LookupError.unknownService because bar-service is not registered
         // Result #2: Later we register bar-service and that should notify the subscriber
-        anyServiceDiscovery.subscribe(to: self.barService, onNext: { result in
+        anyServiceDiscovery.subscribe(to: self.barService, nextResultHandler: { result in
             resultCounter.add(1)
 
             guard resultCounter.load() <= 2 else {


### PR DESCRIPTION
Motivation:
API feedback: `nextResultHandler` and `completionHandler` read better at call sites

Modifications:
Rename `onNext` to `nextResultHandler`, `onComplete` to `completionHandler`