### PR TITLE
Rename internal params/props for subscribe callbacks

### DIFF
--- a/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
@@ -97,7 +97,7 @@ public class InMemoryServiceDiscovery<Service: Hashable, Instance: Hashable>: Se
         // Call `lookup` once and send result to subscriber
         self.lookup(service, callback: onNext)
 
-        let cancellationToken = CancellationToken(onComplete: onComplete)
+        let cancellationToken = CancellationToken(completionHandler: onComplete)
         let subscription = Subscription(onNext: onNext, onComplete: onComplete, cancellationToken: cancellationToken)
 
         // Save the subscription

--- a/Sources/ServiceDiscovery/ServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/ServiceDiscovery.swift
@@ -72,7 +72,7 @@ public protocol ServiceDiscovery: AnyObject {
 /// Enables cancellation of service discovery subscription.
 public class CancellationToken {
     private let _isCancelled: SDAtomic<Bool>
-    private let _onComplete: (CompletionReason) -> Void
+    private let _completionHandler: (CompletionReason) -> Void
 
     /// Returns `true` if the subscription has been cancelled.
     public var isCancelled: Bool {
@@ -80,15 +80,15 @@ public class CancellationToken {
     }
 
     /// Creates a new token.
-    public init(isCancelled: Bool = false, onComplete: @escaping (CompletionReason) -> Void = { _ in }) {
+    public init(isCancelled: Bool = false, completionHandler: @escaping (CompletionReason) -> Void = { _ in }) {
         self._isCancelled = SDAtomic<Bool>(isCancelled)
-        self._onComplete = onComplete
+        self._completionHandler = completionHandler
     }
 
     /// Cancels the subscription.
     public func cancel() {
         guard self._isCancelled.compareAndExchange(expected: false, desired: true) else { return }
-        self._onComplete(.cancellationRequested)
+        self._completionHandler(.cancellationRequested)
     }
 }
 


### PR DESCRIPTION
Motivation:
The `onNext` and `onComplete` callbacks look awkward at times when they are stored/used outside of `subscribe`.

Modifications:
Rename internal parameters and properties to `nextResultHandler` and `completionHandler` instead.