### PR TITLE
Rename isCanceled to isCancelled

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cancellationToken.cancel()
 ```
 
 `subscribe` returns a `CancellationToken` that you can use to cancel the subscription later on. `onComplete` is a closure that
-gets invoked when the subscription ends (e.g., when the service discovery instance shuts down) or gets canceled through the 
+gets invoked when the subscription ends (e.g., when the service discovery instance shuts down) or gets cancelled through the 
 `CancellationToken`. `CompletionReason` can be used to distinguish what leads to the completion.
 
 ## Implementing a service discovery backend
@@ -133,7 +133,7 @@ func subscribe(to service: Service, onNext: @escaping (Result<[Instance], Error>
 - When `subscribe` is first invoked, the caller should receive the current list of instances for the given service. This is essentially the `lookup` result.
 - Whenever the given service's list of instances changes. The backend implementation has full control over how and when its service records get updated, but it must notify `onNext` when the instances list becomes different from the previous result.
 
-A new `CancellationToken` must be created for each `subscribe` request. If the cancellation token's `isCanceled` is `true`, the subscription has been canceled and the backend implementation should cease calling the corresponding `onNext`.
+A new `CancellationToken` must be created for each `subscribe` request. If the cancellation token's `isCancelled` is `true`, the subscription has been cancelled and the backend implementation should cease calling the corresponding `onNext`.
 
 The backend implementation must also notify via `onComplete` when the subscription ends for any reason (e.g., the service discovery instance is shutting down or cancellation is requested through `CancellationToken`), so that the subscriber can submit another `subscribe` request if needed.
 

--- a/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
@@ -91,7 +91,7 @@ public class InMemoryServiceDiscovery<Service: Hashable, Instance: Hashable>: Se
     public func subscribe(to service: Service, onNext: @escaping (Result<[Instance], Error>) -> Void, onComplete: @escaping (CompletionReason) -> Void = { _ in }) -> CancellationToken {
         guard !self.isShutdown else {
             onComplete(.serviceDiscoveryUnavailable)
-            return CancellationToken(isCanceled: true)
+            return CancellationToken(isCancelled: true)
         }
 
         // Call `lookup` once and send result to subscriber
@@ -124,7 +124,7 @@ public class InMemoryServiceDiscovery<Service: Hashable, Instance: Hashable>: Se
             if !self.isShutdown, instances != previousInstances, let subscriptions = self.serviceSubscriptions[service] {
                 // Notify subscribers whenever instances change
                 subscriptions
-                    .filter { !$0.cancellationToken.isCanceled }
+                    .filter { !$0.cancellationToken.isCancelled }
                     .forEach { $0.onNext(.success(instances)) }
             }
         }
@@ -136,7 +136,7 @@ public class InMemoryServiceDiscovery<Service: Hashable, Instance: Hashable>: Se
         self.serviceSubscriptionsLock.withLock {
             self.serviceSubscriptions.values.forEach { subscriptions in
                 subscriptions
-                    .filter { !$0.cancellationToken.isCanceled }
+                    .filter { !$0.cancellationToken.isCancelled }
                     .forEach { $0.onComplete(.serviceDiscoveryUnavailable) }
             }
         }

--- a/Sources/ServiceDiscovery/ServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/ServiceDiscovery.swift
@@ -71,23 +71,23 @@ public protocol ServiceDiscovery: AnyObject {
 
 /// Enables cancellation of service discovery subscription.
 public class CancellationToken {
-    private let _isCanceled: SDAtomic<Bool>
+    private let _isCancelled: SDAtomic<Bool>
     private let _onComplete: (CompletionReason) -> Void
 
-    /// Returns `true` if the subscription has been canceled.
-    public var isCanceled: Bool {
-        self._isCanceled.load()
+    /// Returns `true` if the subscription has been cancelled.
+    public var isCancelled: Bool {
+        self._isCancelled.load()
     }
 
     /// Creates a new token.
-    public init(isCanceled: Bool = false, onComplete: @escaping (CompletionReason) -> Void = { _ in }) {
-        self._isCanceled = SDAtomic<Bool>(isCanceled)
+    public init(isCancelled: Bool = false, onComplete: @escaping (CompletionReason) -> Void = { _ in }) {
+        self._isCancelled = SDAtomic<Bool>(isCancelled)
         self._onComplete = onComplete
     }
 
     /// Cancels the subscription.
     public func cancel() {
-        guard self._isCanceled.compareAndExchange(expected: false, desired: true) else { return }
+        guard self._isCancelled.compareAndExchange(expected: false, desired: true) else { return }
         self._onComplete(.cancellationRequested)
     }
 }


### PR DESCRIPTION
`isCancelled` is more consistent with standard libraries, so will use it
instead.