### PR TITLE
Change internal name of onNext and onComplete params

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,27 +115,31 @@ The backend implementation should impose a deadline on when the operation will c
 ```
 /// Subscribes to receive a service's instances whenever they change.
 ///
-/// The service's current list of instances will be sent to `onNext` when this method is first called. Subsequently,
-/// `onNext` will only be invoked when the `service`'s instances change.
+/// The service's current list of instances will be sent to `nextResultHandler` when this method is first called. Subsequently,
+/// `nextResultHandler` will only be invoked when the `service`'s instances change.
+///
+/// ### Threading
+///
+/// `nextResultHandler` and `completionHandler` may be invoked on arbitrary threads, as determined by implementation.
 ///
 /// - Parameters:
 ///   - service: The service to subscribe to
-///   - onNext: The closure to receive update result
-///   - onComplete: The closure to invoke when the subscription completes (e.g., when the `ServiceDiscovery` instance exits, etc.),
+///   - nextResultHandler: The closure to receive update result
+///   - completionHandler: The closure to invoke when the subscription completes (e.g., when the `ServiceDiscovery` instance exits, etc.),
 ///                 including cancellation requested through `CancellationToken`.
 ///
 /// -  Returns: A `CancellationToken` instance that can be used to cancel the subscription in the future.
-func subscribe(to service: Service, onNext: @escaping (Result<[Instance], Error>) -> Void, onComplete: @escaping (CompletionReason) -> Void) -> CancellationToken
+func subscribe(to service: Service, onNext nextResultHandler: @escaping (Result<[Instance], Error>) -> Void, onComplete completionHandler: @escaping (CompletionReason) -> Void) -> CancellationToken
 ```
 
-`subscribe` "pushes" service instances to the `onNext`. The backend implementation is expected to call `onNext`:
+`subscribe` "pushes" service instances to the `nextResultHandler`. The backend implementation is expected to call `nextResultHandler`:
 
 - When `subscribe` is first invoked, the caller should receive the current list of instances for the given service. This is essentially the `lookup` result.
-- Whenever the given service's list of instances changes. The backend implementation has full control over how and when its service records get updated, but it must notify `onNext` when the instances list becomes different from the previous result.
+- Whenever the given service's list of instances changes. The backend implementation has full control over how and when its service records get updated, but it must notify `nextResultHandler` when the instances list becomes different from the previous result.
 
-A new `CancellationToken` must be created for each `subscribe` request. If the cancellation token's `isCancelled` is `true`, the subscription has been cancelled and the backend implementation should cease calling the corresponding `onNext`.
+A new `CancellationToken` must be created for each `subscribe` request. If the cancellation token's `isCancelled` is `true`, the subscription has been cancelled and the backend implementation should cease calling the corresponding `nextResultHandler`.
 
-The backend implementation must also notify via `onComplete` when the subscription ends for any reason (e.g., the service discovery instance is shutting down or cancellation is requested through `CancellationToken`), so that the subscriber can submit another `subscribe` request if needed.
+The backend implementation must also notify via `completionHandler` when the subscription ends for any reason (e.g., the service discovery instance is shutting down or cancellation is requested through `CancellationToken`), so that the subscriber can submit another `subscribe` request if needed.
 
 ---
 

--- a/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
@@ -88,17 +88,17 @@ public class InMemoryServiceDiscovery<Service: Hashable, Instance: Hashable>: Se
     }
 
     @discardableResult
-    public func subscribe(to service: Service, onNext: @escaping (Result<[Instance], Error>) -> Void, onComplete: @escaping (CompletionReason) -> Void = { _ in }) -> CancellationToken {
+    public func subscribe(to service: Service, onNext nextResultHandler: @escaping (Result<[Instance], Error>) -> Void, onComplete completionHandler: @escaping (CompletionReason) -> Void = { _ in }) -> CancellationToken {
         guard !self.isShutdown else {
-            onComplete(.serviceDiscoveryUnavailable)
+            completionHandler(.serviceDiscoveryUnavailable)
             return CancellationToken(isCancelled: true)
         }
 
         // Call `lookup` once and send result to subscriber
-        self.lookup(service, callback: onNext)
+        self.lookup(service, callback: nextResultHandler)
 
-        let cancellationToken = CancellationToken(completionHandler: onComplete)
-        let subscription = Subscription(onNext: onNext, onComplete: onComplete, cancellationToken: cancellationToken)
+        let cancellationToken = CancellationToken(completionHandler: completionHandler)
+        let subscription = Subscription(nextResultHandler: nextResultHandler, completionHandler: completionHandler, cancellationToken: cancellationToken)
 
         // Save the subscription
         self.serviceSubscriptionsLock.withLock {
@@ -125,7 +125,7 @@ public class InMemoryServiceDiscovery<Service: Hashable, Instance: Hashable>: Se
                 // Notify subscribers whenever instances change
                 subscriptions
                     .filter { !$0.cancellationToken.isCancelled }
-                    .forEach { $0.onNext(.success(instances)) }
+                    .forEach { $0.nextResultHandler(.success(instances)) }
             }
         }
     }
@@ -137,14 +137,14 @@ public class InMemoryServiceDiscovery<Service: Hashable, Instance: Hashable>: Se
             self.serviceSubscriptions.values.forEach { subscriptions in
                 subscriptions
                     .filter { !$0.cancellationToken.isCancelled }
-                    .forEach { $0.onComplete(.serviceDiscoveryUnavailable) }
+                    .forEach { $0.completionHandler(.serviceDiscoveryUnavailable) }
             }
         }
     }
 
     private struct Subscription {
-        let onNext: (Result<[Instance], Error>) -> Void
-        let onComplete: (CompletionReason) -> Void
+        let nextResultHandler: (Result<[Instance], Error>) -> Void
+        let completionHandler: (CompletionReason) -> Void
         let cancellationToken: CancellationToken
     }
 }

--- a/Sources/ServiceDiscovery/ServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/ServiceDiscovery.swift
@@ -50,21 +50,21 @@ public protocol ServiceDiscovery: AnyObject {
 
     /// Subscribes to receive a service's instances whenever they change.
     ///
-    /// The service's current list of instances will be sent to `onNext` when this method is first called. Subsequently,
-    /// `onNext` will only be invoked when the `service`'s instances change.
+    /// The service's current list of instances will be sent to `nextResultHandler` when this method is first called. Subsequently,
+    /// `nextResultHandler` will only be invoked when the `service`'s instances change.
     ///
     /// ### Threading
     ///
-    /// `onNext` and `onComplete` may be invoked on arbitrary threads, as determined by implementation.
+    /// `nextResultHandler` and `completionHandler` may be invoked on arbitrary threads, as determined by implementation.
     ///
     /// - Parameters:
     ///   - service: The service to subscribe to
-    ///   - onNext: The closure to receive update result
-    ///   - onComplete: The closure to invoke when the subscription completes (e.g., when the `ServiceDiscovery` instance exits, etc.),
+    ///   - nextResultHandler: The closure to receive update result
+    ///   - completionHandler: The closure to invoke when the subscription completes (e.g., when the `ServiceDiscovery` instance exits, etc.),
     ///                 including cancellation requested through `CancellationToken`.
     ///
     /// -  Returns: A `CancellationToken` instance that can be used to cancel the subscription in the future.
-    func subscribe(to service: Service, onNext: @escaping (Result<[Instance], Error>) -> Void, onComplete: @escaping (CompletionReason) -> Void) -> CancellationToken
+    func subscribe(to service: Service, onNext nextResultHandler: @escaping (Result<[Instance], Error>) -> Void, onComplete completionHandler: @escaping (CompletionReason) -> Void) -> CancellationToken
 }
 
 // MARK: - Subscription


### PR DESCRIPTION
Per API review, `onNext` to `nextResultHandler` and `onComplete` to `completionHandler`