### PR TITLE
[Draft] Add async/await support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .target(name: "ServiceDiscoveryHelpers", dependencies: ["CServiceDiscoveryHelpers"]),
 
         .target(name: "ServiceDiscovery", dependencies: ["ServiceDiscoveryHelpers", "Logging"]),
+        .target(name: "AsyncAwaitServiceDiscovery", dependencies: ["ServiceDiscoveryHelpers", "Logging"]),
 
         .testTarget(name: "ServiceDiscoveryHelpersTests", dependencies: ["ServiceDiscoveryHelpers"]),
         .testTarget(name: "ServiceDiscoveryTests", dependencies: ["ServiceDiscovery"]),

--- a/Sources/AsyncAwaitServiceDiscovery/InMemoryServiceDiscovery.swift
+++ b/Sources/AsyncAwaitServiceDiscovery/InMemoryServiceDiscovery.swift
@@ -1,0 +1,199 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftServiceDiscovery open source project
+//
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftServiceDiscovery project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftServiceDiscovery project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import Foundation
+import ServiceDiscoveryHelpers
+
+#if compiler(>=5.5)
+/// Provides lookup for service instances that are stored in-memory.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public class InMemoryServiceDiscovery<Service: Hashable, Instance: Hashable>: ServiceDiscovery {
+    private let configuration: Configuration
+
+    private let serviceInstancesLock = NSLock()
+    private var serviceInstances: [Service: [Instance]]
+
+    private let serviceSubscriptionsLock = NSLock()
+    private var serviceSubscriptions: [Service: [Subscription]] = [:]
+
+    private let queue: DispatchQueue
+
+    public var defaultLookupTimeout: DispatchTimeInterval {
+        self.configuration.defaultLookupTimeout
+    }
+
+    private let _isShutdown = SDAtomic<Bool>(false)
+
+    public var isShutdown: Bool {
+        self._isShutdown.load()
+    }
+
+    public init(configuration: Configuration, queue: DispatchQueue = .init(label: "InMemoryServiceDiscovery", attributes: .concurrent)) {
+        self.configuration = configuration
+        self.serviceInstances = configuration.serviceInstances
+        self.queue = queue
+    }
+
+    public func lookup(_ service: Service, deadline: DispatchTime? = nil) async throws -> [Instance] {
+        guard !self.isShutdown else {
+            throw ServiceDiscoveryError.unavailable
+        }
+
+        let instancesHandle: Task.Handle<[Instance], Error> = detach {
+            let instances = self.serviceInstancesLock.withLock {
+                self.serviceInstances[service]
+            }
+            // This task is cancelled at deadline
+            guard !Task.isCancelled else {
+                throw LookupError.timedOut
+            }
+            guard let instances = instances else {
+                throw LookupError.unknownService
+            }
+            return instances
+        }
+
+        // Timeout handler
+        self.queue.asyncAfter(deadline: deadline ?? DispatchTime.now() + self.defaultLookupTimeout) {
+            instancesHandle.cancel()
+        }
+
+        return try await instancesHandle.get()
+    }
+
+    public func subscribe(to service: Service) throws -> AsyncThrowingStream<[Instance]> {
+        guard !self.isShutdown else {
+            throw ServiceDiscoveryError.unavailable
+        }
+
+        return AsyncThrowingStream { continuation in
+            detach { () -> Void in
+                // Call `lookup` once and send it as the first stream element
+                do {
+                    let instances = try await self.lookup(service)
+                    continuation.yield(instances)
+                } catch is LookupError {
+                    // LookupError is recoverable (e.g., service is added *after* subscription begins, so don't bail yet
+                } catch {
+                    return continuation.finish(throwing: error)
+                }
+
+                // Create subscription
+                let subscription = Subscription(
+                    id: UUID(),
+                    nextResultHandler: { instances in continuation.yield(instances) },
+                    completionHandler: { error in
+                        if let error = error {
+                            continuation.finish(throwing: error)
+                        } else {
+                            continuation.finish()
+                        }
+                    }
+                )
+
+                // Save the subscription
+                self.serviceSubscriptionsLock.withLock {
+                    var subscriptions = self.serviceSubscriptions.removeValue(forKey: service) ?? [Subscription]()
+                    subscriptions.append(subscription)
+                    self.serviceSubscriptions[service] = subscriptions
+                }
+
+                // Remove the subscription when it terminates
+                continuation.onTermination = { @Sendable(_) -> Void in
+                    self.serviceSubscriptionsLock.withLock {
+                        var subscriptions = self.serviceSubscriptions.removeValue(forKey: service) ?? [Subscription]()
+                        subscriptions.removeAll { $0.id == subscription.id }
+                        self.serviceSubscriptions[service] = subscriptions
+                    }
+                }
+            }
+        }
+    }
+
+    /// Registers a service and its `instances`.
+    public func register(_ service: Service, instances: [Instance]) {
+        guard !self.isShutdown else { return }
+
+        var previousInstances: [Instance]?
+        self.serviceInstancesLock.withLock {
+            previousInstances = self.serviceInstances[service]
+            self.serviceInstances[service] = instances
+        }
+
+        self.serviceSubscriptionsLock.withLock {
+            if !self.isShutdown, instances != previousInstances, let subscriptions = self.serviceSubscriptions[service] {
+                // Notify subscribers whenever instances change
+                subscriptions.forEach { $0.nextResultHandler(instances) }
+            }
+        }
+    }
+
+    public func shutdown() {
+        guard self._isShutdown.compareAndExchange(expected: false, desired: true) else { return }
+
+        self.serviceSubscriptionsLock.withLock {
+            self.serviceSubscriptions.values.forEach { subscriptions in
+                subscriptions.forEach { $0.completionHandler(ServiceDiscoveryError.unavailable) }
+            }
+        }
+    }
+
+    private struct Subscription {
+        let id: UUID
+        let nextResultHandler: ([Instance]) -> Void
+        let completionHandler: (Error?) -> Void
+    }
+}
+
+extension InMemoryServiceDiscovery {
+    public struct Configuration {
+        /// Default configuration
+        public static var `default`: Configuration {
+            .init()
+        }
+
+        /// Lookup timeout in case `deadline` is not specified
+        public var defaultLookupTimeout: DispatchTimeInterval = .milliseconds(100)
+
+        internal var serviceInstances: [Service: [Instance]]
+
+        public init() {
+            self.init(serviceInstances: [:])
+        }
+
+        /// Initializes `InMemoryServiceDiscovery` with the given service to instances mappings.
+        public init(serviceInstances: [Service: [Instance]]) {
+            self.serviceInstances = serviceInstances
+        }
+
+        /// Registers `service` and its `instances`.
+        public mutating func register(service: Service, instances: [Instance]) {
+            self.serviceInstances[service] = instances
+        }
+    }
+}
+#endif
+
+// MARK: - NSLock extensions
+
+extension NSLock {
+    fileprivate func withLock<Value>(_ body: () throws -> Value) rethrows -> Value {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+}

--- a/Sources/AsyncAwaitServiceDiscovery/ServiceDiscovery.swift
+++ b/Sources/AsyncAwaitServiceDiscovery/ServiceDiscovery.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftServiceDiscovery open source project
+//
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftServiceDiscovery project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftServiceDiscovery project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+
+#if compiler(>=5.5)
+/// Provides service instances lookup.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public protocol ServiceDiscovery: AnyObject {
+    /// Service identity type
+    associatedtype Service: Hashable
+    /// Service instance type
+    associatedtype Instance: Hashable
+
+    /// Default timeout for lookup.
+    var defaultLookupTimeout: DispatchTimeInterval { get }
+
+    /// Performs a lookup for the given service's instances.
+    ///
+    /// `defaultLookupTimeout` will be used to compute `deadline` in case one is not specified.
+    ///
+    /// - Parameters:
+    ///   - service: The service to lookup
+    ///   - deadline: Lookup is considered to have timed out if it does not complete by this time
+    ///
+    /// - Returns: The service's instances. An error is thrown in case `service` is unknown.
+    func lookup(_ service: Service, deadline: DispatchTime?) async throws -> [Instance]
+
+    /// Subscribes to receive a service's instances whenever they change.
+    ///
+    /// The service's current list of instances will be sent as the first element of the stream. Subsequent elements
+    /// are produced only when the `service`'s instances change.
+    ///
+    /// - Parameters:
+    ///   - service: The service to subscribe to
+    ///
+    /// -  Returns: A stream of the service's instances as they are updated.
+    func subscribe(to service: Service) async throws -> AsyncThrowingStream<[Instance]>
+}
+#endif
+
+// MARK: - Service discovery errors
+
+/// Errors that might occur during lookup.
+public struct LookupError: Error, Equatable, CustomStringConvertible {
+    internal enum ErrorType: Equatable, CustomStringConvertible {
+        case unknownService
+        case timedOut
+
+        var description: String {
+            switch self {
+            case .unknownService:
+                return "unknownService"
+            case .timedOut:
+                return "timedOut"
+            }
+        }
+    }
+
+    internal let type: ErrorType
+
+    public var description: String {
+        "LookupError.\(String(describing: self.type))"
+    }
+
+    /// Lookup cannot be completed because the service is unknown.
+    public static let unknownService = LookupError(type: .unknownService)
+
+    /// Lookup has taken longer than allowed and thus has timed out.
+    public static let timedOut = LookupError(type: .timedOut)
+}
+
+/// General service discovery errors.
+public struct ServiceDiscoveryError: Error, Equatable, CustomStringConvertible {
+    internal enum ErrorType: Equatable, CustomStringConvertible {
+        case unavailable
+
+        var description: String {
+            switch self {
+            case .unavailable:
+                return "unavailable"
+            }
+        }
+    }
+
+    internal let type: ErrorType
+
+    public var description: String {
+        "ServiceDiscoveryError.\(String(describing: self.type))"
+    }
+
+    /// `ServiceDiscovery` instance is unavailable.
+    public static let unavailable = ServiceDiscoveryError(type: .unavailable)
+}

--- a/Sources/ServiceDiscovery/FilterInstanceServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/FilterInstanceServiceDiscovery.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2020 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2020-2021 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
 import Dispatch
 import ServiceDiscoveryHelpers
 
@@ -57,3 +58,13 @@ extension FilterInstanceServiceDiscovery: ServiceDiscovery {
         }
     }
 }
+
+#if compiler(>=5.5)
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+extension FilterInstanceServiceDiscovery: AsyncServiceDiscovery where BaseDiscovery: AsyncServiceDiscovery {
+    public func lookup(_ service: BaseDiscovery.Service, deadline: DispatchTime?) async throws -> [BaseDiscovery.Instance] {
+        let instances = try await self.originalSD.lookup(service, deadline: deadline)
+        return try instances.filter(self.predicate)
+    }
+}
+#endif

--- a/Sources/ServiceDiscovery/MapInstanceServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/MapInstanceServiceDiscovery.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2020 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2020-2021 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
 import Dispatch
 import ServiceDiscoveryHelpers
 
@@ -57,3 +58,13 @@ extension MapInstanceServiceDiscovery: ServiceDiscovery {
         }
     }
 }
+
+#if compiler(>=5.5)
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+extension MapInstanceServiceDiscovery: AsyncServiceDiscovery where BaseDiscovery: AsyncServiceDiscovery {
+    public func lookup(_ service: BaseDiscovery.Service, deadline: DispatchTime?) async throws -> [DerivedInstance] {
+        let instances = try await self.originalSD.lookup(service, deadline: deadline)
+        return try instances.map(self.transformer)
+    }
+}
+#endif

--- a/Sources/ServiceDiscovery/MapServiceServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/MapServiceServiceDiscovery.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2020 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2020-2021 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
 import Dispatch
 import ServiceDiscoveryHelpers
 
@@ -65,3 +66,13 @@ extension MapServiceServiceDiscovery: ServiceDiscovery {
         )
     }
 }
+
+#if compiler(>=5.5)
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+extension MapServiceServiceDiscovery: AsyncServiceDiscovery where BaseDiscovery: AsyncServiceDiscovery {
+    public func lookup(_ service: ComputedService, deadline: DispatchTime?) async throws -> [BaseDiscovery.Instance] {
+        let derivedService = try self.transformer(service)
+        return try await self.originalSD.lookup(derivedService, deadline: deadline)
+    }
+}
+#endif

--- a/Sources/ServiceDiscovery/ServiceDiscovery+TypeErased.swift
+++ b/Sources/ServiceDiscovery/ServiceDiscovery+TypeErased.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2020 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2020-2021 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -67,6 +67,63 @@ public class ServiceDiscoveryBox<Service: Hashable, Instance: Hashable>: Service
         return unwrapped
     }
 }
+
+// MARK: - Generic wrapper for `AsyncServiceDiscovery` instance
+
+#if compiler(>=5.5)
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public class AsyncServiceDiscoveryBox<Service: Hashable, Instance: Hashable>: AsyncServiceDiscovery {
+    private let _underlying: Any
+
+    private let _defaultLookupTimeout: () -> DispatchTimeInterval
+
+    private let _lookup: (Service, DispatchTime?) async throws -> [Instance]
+
+    private let _subscribe: (Service, @escaping (Result<[Instance], Error>) -> Void, @escaping (CompletionReason) -> Void) -> CancellationToken
+
+    public var defaultLookupTimeout: DispatchTimeInterval {
+        self._defaultLookupTimeout()
+    }
+
+    public init<ServiceDiscoveryImpl: AsyncServiceDiscovery>(_ serviceDiscovery: ServiceDiscoveryImpl)
+        where ServiceDiscoveryImpl.Service == Service, ServiceDiscoveryImpl.Instance == Instance {
+        self._underlying = serviceDiscovery
+        self._defaultLookupTimeout = { serviceDiscovery.defaultLookupTimeout }
+
+        self._lookup = { service, deadline async throws in
+            try await serviceDiscovery.lookup(service, deadline: deadline)
+        }
+        self._subscribe = { service, nextResultHandler, completionHandler in
+            serviceDiscovery.subscribe(to: service, onNext: nextResultHandler, onComplete: completionHandler)
+        }
+    }
+
+    public func lookup(_ service: Service, deadline: DispatchTime? = nil) async throws -> [Instance] {
+        try await self._lookup(service, deadline)
+    }
+
+    @discardableResult
+    public func subscribe(
+        to service: Service,
+        onNext nextResultHandler: @escaping (Result<[Instance], Error>) -> Void,
+        onComplete completionHandler: @escaping (CompletionReason) -> Void = { _ in }
+    ) -> CancellationToken {
+        self._subscribe(service, nextResultHandler, completionHandler)
+    }
+
+    /// Unwraps the underlying `AsyncServiceDiscovery` instance as `ServiceDiscoveryImpl` type.
+    ///
+    /// - Throws: ` TypeErasedServiceDiscoveryError.typeMismatch` when the underlying
+    ///           `AsyncServiceDiscovery` instance is not of type `ServiceDiscoveryImpl`.
+    @discardableResult
+    public func unwrapAs<ServiceDiscoveryImpl: AsyncServiceDiscovery>(_ serviceDiscoveryType: ServiceDiscoveryImpl.Type) throws -> ServiceDiscoveryImpl {
+        guard let unwrapped = self._underlying as? ServiceDiscoveryImpl else {
+            throw TypeErasedServiceDiscoveryError.typeMismatch(description: "Cannot unwrap [\(type(of: self._underlying)))] as [\(ServiceDiscoveryImpl.self)]")
+        }
+        return unwrapped
+    }
+}
+#endif
 
 // MARK: - Type-erased wrapper for `ServiceDiscovery` instance
 
@@ -175,6 +232,120 @@ public class AnyServiceDiscovery: ServiceDiscovery {
         return unwrapped
     }
 }
+
+// MARK: - Type-erased wrapper for `AsyncServiceDiscovery` instance
+
+#if compiler(>=5.5)
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public class AnyAsyncServiceDiscovery: AsyncServiceDiscovery {
+    private let _underlying: Any
+
+    private let _defaultLookupTimeout: () -> DispatchTimeInterval
+
+    private let _lookup: (AnyHashable, DispatchTime?) async throws -> [AnyHashable]
+
+    private let _subscribe: (AnyHashable, @escaping (Result<[AnyHashable], Error>) -> Void, @escaping (CompletionReason) -> Void) -> CancellationToken
+
+    public var defaultLookupTimeout: DispatchTimeInterval {
+        self._defaultLookupTimeout()
+    }
+
+    public init<ServiceDiscoveryImpl: AsyncServiceDiscovery>(_ serviceDiscovery: ServiceDiscoveryImpl) {
+        self._underlying = serviceDiscovery
+        self._defaultLookupTimeout = { serviceDiscovery.defaultLookupTimeout }
+
+        self._lookup = { anyService, deadline async throws in
+            guard let service = anyService.base as? ServiceDiscoveryImpl.Service else {
+                preconditionFailure("Expected service type to be \(ServiceDiscoveryImpl.Service.self), got \(type(of: anyService.base))")
+            }
+            let instances = try await serviceDiscovery.lookup(service, deadline: deadline)
+            return instances.map(AnyHashable.init)
+        }
+        self._subscribe = { anyService, nextResultHandler, completionHandler in
+            guard let service = anyService.base as? ServiceDiscoveryImpl.Service else {
+                preconditionFailure("Expected service type to be \(ServiceDiscoveryImpl.Service.self), got \(type(of: anyService.base))")
+            }
+            return serviceDiscovery.subscribe(
+                to: service,
+                onNext: { result in nextResultHandler(result.map { $0.map(AnyHashable.init) }) },
+                onComplete: completionHandler
+            )
+        }
+    }
+
+    /// See `AsyncServiceDiscovery.lookup`.
+    ///
+    /// - Warning: If `service` type does not match the underlying `AsyncServiceDiscovery`'s, it would result in a failure.
+    public func lookup(_ service: AnyHashable, deadline: DispatchTime? = nil) async throws -> [AnyHashable] {
+        try await self._lookup(service, deadline)
+    }
+
+    /// See `lookup`.
+    ///
+    /// - Warning: If `Service` or `Instance` type does not match the underlying `AsyncServiceDiscovery`'s associated types, it would result in a failure.
+    public func lookupAndUnwrap<Service, Instance>(_ service: Service, deadline: DispatchTime? = nil) async throws -> [Instance] where Service: Hashable, Instance: Hashable {
+        let anyInstances = try await self._lookup(AnyHashable(service), deadline)
+        return try self.transform(anyInstances)
+    }
+
+    /// See `ServiceDiscovery.subscribe`.
+    ///
+    /// - Warning: If `service` type does not match the underlying `AsyncServiceDiscovery`'s, it would result in a failure.
+    @discardableResult
+    public func subscribe(
+        to service: AnyHashable,
+        onNext nextResultHandler: @escaping (Result<[AnyHashable], Error>) -> Void,
+        onComplete completionHandler: @escaping (CompletionReason) -> Void = { _ in }
+    ) -> CancellationToken {
+        self._subscribe(service, nextResultHandler, completionHandler)
+    }
+
+    /// See `subscribe`.
+    ///
+    /// - Warning: If `Service` or `Instance` type does not match the underlying `AsyncServiceDiscovery`'s associated types, it would result in a failure.
+    @discardableResult
+    public func subscribeAndUnwrap<Service, Instance>(
+        to service: Service,
+        onNext nextResultHandler: @escaping (Result<[Instance], Error>) -> Void,
+        onComplete completionHandler: @escaping (CompletionReason) -> Void = { _ in }
+    ) -> CancellationToken where Service: Hashable, Instance: Hashable {
+        self._subscribe(AnyHashable(service), { result in nextResultHandler(self.transform(result)) }, completionHandler)
+    }
+
+    private func transform<Instance>(_ result: Result<[AnyHashable], Error>) -> Result<[Instance], Error> where Instance: Hashable {
+        result.flatMap { anyInstances in
+            do {
+                let instances: [Instance] = try self.transform(anyInstances)
+                return .success(instances)
+            } catch {
+                return .failure(error)
+            }
+        }
+    }
+
+    private func transform<Instance>(_ anyInstances: [AnyHashable]) throws -> [Instance] where Instance: Hashable {
+        try anyInstances.map { anyInstance in
+            guard let instance = anyInstance.base as? Instance else {
+                throw TypeErasedServiceDiscoveryError.typeMismatch(description: "Expected instance type to be \(Instance.self), got \(type(of: anyInstance.base))")
+            }
+            return instance
+        }
+    }
+
+    /// Unwraps the underlying `AsyncServiceDiscovery` instance as `ServiceDiscoveryImpl` type.
+    ///
+    /// - Throws: ` TypeErasedServiceDiscoveryError.typeMismatch` when the underlying
+    ///           `AsyncServiceDiscovery` instance is not of type `ServiceDiscoveryImpl`.
+    public func unwrapAs<ServiceDiscoveryImpl: AsyncServiceDiscovery>(_ serviceDiscoveryType: ServiceDiscoveryImpl.Type) throws -> ServiceDiscoveryImpl {
+        guard let unwrapped = self._underlying as? ServiceDiscoveryImpl else {
+            throw TypeErasedServiceDiscoveryError.typeMismatch(description: "Cannot unwrap [\(type(of: self._underlying))] as [\(ServiceDiscoveryImpl.self)]")
+        }
+        return unwrapped
+    }
+}
+#endif
+
+// MARK: - Errors
 
 public enum TypeErasedServiceDiscoveryError: Error {
     case typeMismatch(description: String)

--- a/Tests/ServiceDiscoveryTests/FilterInstanceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/FilterInstanceServiceDiscoveryTests.swift
@@ -92,25 +92,23 @@ class FilterInstanceServiceDiscoveryTests: XCTestCase {
 
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).filterInstance { [7001, 9001, 9002].contains($0.port) }
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 let _fooInstances = try await serviceDiscovery.lookup(self.fooService, deadline: nil)
 
                 XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(self.fooService)] to have 1 instance, got \(_fooInstances.count)")
                 XCTAssertEqual(_fooInstances, self.fooDerivedInstances, "Expected service[\(self.fooService)] to have instances \(self.fooDerivedInstances), got \(_fooInstances)")
-                expectation.fulfill()
             } catch {
                 XCTFail("Failed to lookup instances for service[\(self.fooService)]: \(error)")
             }
         }
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 let _barInstances = try await serviceDiscovery.lookup(self.barService, deadline: nil)
 
                 XCTAssertEqual(_barInstances.count, 2, "Expected service[\(self.barService)] to have 2 instances, got \(_barInstances.count)")
                 XCTAssertEqual(_barInstances, self.barDerivedInstances, "Expected service[\(self.barService)] to have instances \(self.barDerivedInstances), got \(_barInstances)")
-                expectation.fulfill()
             } catch {
                 XCTFail("Failed to lookup instances for service[\(self.barService)] \(error)")
             }
@@ -133,7 +131,7 @@ class FilterInstanceServiceDiscoveryTests: XCTestCase {
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: ["foo-service": []])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).filterInstance { $0.port == 7001 }
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 _ = try await serviceDiscovery.lookup(unknownService, deadline: nil)
                 XCTFail("Lookup instances for service[\(unknownService)] should return an error")
@@ -141,7 +139,6 @@ class FilterInstanceServiceDiscoveryTests: XCTestCase {
                 guard let lookupError = error as? LookupError, case .unknownService = lookupError else {
                     return XCTFail("Expected LookupError.unknownService, got \(error)")
                 }
-                expectation.fulfill()
             }
         }
         #endif

--- a/Tests/ServiceDiscoveryTests/InMemoryServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/InMemoryServiceDiscoveryTests.swift
@@ -84,25 +84,23 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
 
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 let _fooInstances = try await serviceDiscovery.lookup(self.fooService)
 
                 XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(self.fooService)] to have 1 instance, got \(_fooInstances.count)")
                 XCTAssertEqual(_fooInstances, self.fooInstances, "Expected service[\(self.fooService)] to have instances \(self.fooInstances), got \(_fooInstances)")
-                expectation.fulfill()
             } catch {
                 XCTFail("Failed to lookup instances for service[\(self.fooService)]: \(error)")
             }
         }
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 let _barInstances = try await serviceDiscovery.lookup(self.barService)
 
                 XCTAssertEqual(_barInstances.count, 2, "Expected service[\(self.barService)] to have 2 instances, got \(_barInstances.count)")
                 XCTAssertEqual(_barInstances, self.barInstances, "Expected service[\(self.barService)] to have instances \(self.barInstances), got \(_barInstances)")
-                expectation.fulfill()
             } catch {
                 XCTFail("Failed to lookup instances for service[\(self.barService)] \(error)")
             }
@@ -125,7 +123,7 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: ["foo-service": []])
         let serviceDiscovery = InMemoryServiceDiscovery<Service, Instance>(configuration: configuration)
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 _ = try await serviceDiscovery.lookup(unknownService)
                 XCTFail("Lookup instances for service[\(unknownService)] should return an error")
@@ -133,7 +131,6 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
                 guard let lookupError = error as? LookupError, case .unknownService = lookupError else {
                     return XCTFail("Expected LookupError.unknownService, got \(error)")
                 }
-                expectation.fulfill()
             }
         }
         #endif

--- a/Tests/ServiceDiscoveryTests/InMemoryServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/InMemoryServiceDiscoveryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
+
 @testable import ServiceDiscovery
 import ServiceDiscoveryHelpers
 import XCTest
@@ -66,6 +67,76 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
         guard let lookupError = error as? LookupError, case .unknownService = lookupError else {
             return XCTFail("Expected LookupError.unknownService, got \(error)")
         }
+    }
+
+    func test_async_lookup() throws {
+        #if compiler(<5.2)
+        return
+        #elseif compiler(<5.5)
+        throw XCTSkip("async/await not supported")
+        #else
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+            throw XCTSkip("async/await not supported")
+        }
+
+        var configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [fooService: self.fooInstances])
+        configuration.register(service: self.barService, instances: self.barInstances)
+
+        let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
+
+        runAsyncAndWaitFor { expectation in
+            do {
+                let _fooInstances = try await serviceDiscovery.lookup(self.fooService)
+
+                XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(self.fooService)] to have 1 instance, got \(_fooInstances.count)")
+                XCTAssertEqual(_fooInstances, self.fooInstances, "Expected service[\(self.fooService)] to have instances \(self.fooInstances), got \(_fooInstances)")
+                expectation.fulfill()
+            } catch {
+                XCTFail("Failed to lookup instances for service[\(self.fooService)]: \(error)")
+            }
+        }
+
+        runAsyncAndWaitFor { expectation in
+            do {
+                let _barInstances = try await serviceDiscovery.lookup(self.barService)
+
+                XCTAssertEqual(_barInstances.count, 2, "Expected service[\(self.barService)] to have 2 instances, got \(_barInstances.count)")
+                XCTAssertEqual(_barInstances, self.barInstances, "Expected service[\(self.barService)] to have instances \(self.barInstances), got \(_barInstances)")
+                expectation.fulfill()
+            } catch {
+                XCTFail("Failed to lookup instances for service[\(self.barService)] \(error)")
+            }
+        }
+        #endif
+    }
+
+    func test_async_lookup_errorIfServiceUnknown() throws {
+        #if compiler(<5.2)
+        return
+        #elseif compiler(<5.5)
+        throw XCTSkip("async/await not supported")
+        #else
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+            throw XCTSkip("async/await not supported")
+        }
+
+        let unknownService = "unknown-service"
+
+        let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: ["foo-service": []])
+        let serviceDiscovery = InMemoryServiceDiscovery<Service, Instance>(configuration: configuration)
+
+        runAsyncAndWaitFor { expectation in
+            do {
+                _ = try await serviceDiscovery.lookup(unknownService)
+                XCTFail("Lookup instances for service[\(unknownService)] should return an error")
+            } catch {
+                guard let lookupError = error as? LookupError, case .unknownService = lookupError else {
+                    return XCTFail("Expected LookupError.unknownService, got \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+        #endif
     }
 
     func test_subscribe() throws {
@@ -241,23 +312,5 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
 
         XCTAssertEqual(registerCounter.load(), times, "Expected register to succeed \(times) times")
         XCTAssertEqual(lookupCounter.load(), times, "Expected lookup callback to be called \(times) times")
-    }
-
-    private func ensureResult(serviceDiscovery: InMemoryServiceDiscovery<Service, Instance>, service: Service) throws -> Result<[Instance], Error> {
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<[Instance], Error>?
-
-        serviceDiscovery.lookup(service) {
-            result = $0
-            semaphore.signal()
-        }
-
-        _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(1))
-
-        guard let _result = result else {
-            throw LookupError.timedOut
-        }
-
-        return _result
     }
 }

--- a/Tests/ServiceDiscoveryTests/MapInstanceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/MapInstanceServiceDiscoveryTests.swift
@@ -91,25 +91,23 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
 
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).mapInstance { port in HostPort(host: "localhost", port: port) }
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 let _fooInstances = try await serviceDiscovery.lookup(self.fooService, deadline: nil)
 
                 XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(self.fooService)] to have 1 instance, got \(_fooInstances.count)")
                 XCTAssertEqual(_fooInstances, self.fooDerivedInstances, "Expected service[\(self.fooService)] to have instances \(self.fooDerivedInstances), got \(_fooInstances)")
-                expectation.fulfill()
             } catch {
                 XCTFail("Failed to lookup instances for service[\(self.fooService)]: \(error)")
             }
         }
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 let _barInstances = try await serviceDiscovery.lookup(self.barService, deadline: nil)
 
                 XCTAssertEqual(_barInstances.count, 2, "Expected service[\(self.barService)] to have 2 instances, got \(_barInstances.count)")
                 XCTAssertEqual(_barInstances, self.barDerivedInstances, "Expected service[\(self.barService)] to have instances \(self.barDerivedInstances), got \(_barInstances)")
-                expectation.fulfill()
             } catch {
                 XCTFail("Failed to lookup instances for service[\(self.barService)] \(error)")
             }
@@ -132,7 +130,7 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
         let configuration = InMemoryServiceDiscovery<Service, BaseInstance>.Configuration(serviceInstances: ["foo-service": []])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).mapInstance { port in HostPort(host: "localhost", port: port) }
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 _ = try await serviceDiscovery.lookup(unknownService, deadline: nil)
                 XCTFail("Lookup instances for service[\(unknownService)] should return an error")
@@ -140,7 +138,6 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
                 guard let lookupError = error as? LookupError, case .unknownService = lookupError else {
                     return XCTFail("Expected LookupError.unknownService, got \(error)")
                 }
-                expectation.fulfill()
             }
         }
         #endif

--- a/Tests/ServiceDiscoveryTests/MapInstanceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/MapInstanceServiceDiscoveryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -74,6 +74,76 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
         guard let lookupError = error as? LookupError, case .unknownService = lookupError else {
             return XCTFail("Expected LookupError.unknownService, got \(error)")
         }
+    }
+
+    func test_async_lookup() throws {
+        #if compiler(<5.2)
+        return
+        #elseif compiler(<5.5)
+        throw XCTSkip("async/await not supported")
+        #else
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+            throw XCTSkip("async/await not supported")
+        }
+
+        var configuration = InMemoryServiceDiscovery<Service, BaseInstance>.Configuration(serviceInstances: [fooService: self.fooBaseInstances])
+        configuration.register(service: self.barService, instances: self.barBaseInstances)
+
+        let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).mapInstance { port in HostPort(host: "localhost", port: port) }
+
+        runAsyncAndWaitFor { expectation in
+            do {
+                let _fooInstances = try await serviceDiscovery.lookup(self.fooService, deadline: nil)
+
+                XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(self.fooService)] to have 1 instance, got \(_fooInstances.count)")
+                XCTAssertEqual(_fooInstances, self.fooDerivedInstances, "Expected service[\(self.fooService)] to have instances \(self.fooDerivedInstances), got \(_fooInstances)")
+                expectation.fulfill()
+            } catch {
+                XCTFail("Failed to lookup instances for service[\(self.fooService)]: \(error)")
+            }
+        }
+
+        runAsyncAndWaitFor { expectation in
+            do {
+                let _barInstances = try await serviceDiscovery.lookup(self.barService, deadline: nil)
+
+                XCTAssertEqual(_barInstances.count, 2, "Expected service[\(self.barService)] to have 2 instances, got \(_barInstances.count)")
+                XCTAssertEqual(_barInstances, self.barDerivedInstances, "Expected service[\(self.barService)] to have instances \(self.barDerivedInstances), got \(_barInstances)")
+                expectation.fulfill()
+            } catch {
+                XCTFail("Failed to lookup instances for service[\(self.barService)] \(error)")
+            }
+        }
+        #endif
+    }
+
+    func test_async_lookup_errorIfServiceUnknown() throws {
+        #if compiler(<5.2)
+        return
+        #elseif compiler(<5.5)
+        throw XCTSkip("async/await not supported")
+        #else
+        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+            throw XCTSkip("async/await not supported")
+        }
+
+        let unknownService = "unknown-service"
+
+        let configuration = InMemoryServiceDiscovery<Service, BaseInstance>.Configuration(serviceInstances: ["foo-service": []])
+        let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).mapInstance { port in HostPort(host: "localhost", port: port) }
+
+        runAsyncAndWaitFor { expectation in
+            do {
+                _ = try await serviceDiscovery.lookup(unknownService, deadline: nil)
+                XCTFail("Lookup instances for service[\(unknownService)] should return an error")
+            } catch {
+                guard let lookupError = error as? LookupError, case .unknownService = lookupError else {
+                    return XCTFail("Expected LookupError.unknownService, got \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+        #endif
     }
 
     func test_subscribe() throws {
@@ -263,7 +333,7 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
         let configuration = InMemoryServiceDiscovery.Configuration(serviceInstances: [fooService: self.fooBaseInstances])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).mapInstance { _ -> Int in throw TestError.error }
 
-        let result = try self.ensureResult(serviceDiscovery: serviceDiscovery, service: self.fooService)
+        let result = try ensureResult(serviceDiscovery: serviceDiscovery, service: self.fooService)
         guard case .failure(let err) = result else {
             XCTFail("Expected failure, got \(result)")
             return
@@ -275,24 +345,6 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
         let configuration = InMemoryServiceDiscovery<Service, BaseInstance>.Configuration(serviceInstances: ["foo-service": []])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).mapInstance { port in HostPort(host: "localhost", port: port) }
         XCTAssertTrue(Self.compareTimeInterval(configuration.defaultLookupTimeout, serviceDiscovery.defaultLookupTimeout), "\(configuration.defaultLookupTimeout) does not match \(serviceDiscovery.defaultLookupTimeout)")
-    }
-
-    private func ensureResult<SD: ServiceDiscovery>(serviceDiscovery: SD, service: SD.Service) throws -> Result<[SD.Instance], Error> {
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<[SD.Instance], Error>?
-
-        serviceDiscovery.lookup(service, deadline: nil) {
-            result = $0
-            semaphore.signal()
-        }
-
-        _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(1))
-
-        guard let _result = result else {
-            throw LookupError.timedOut
-        }
-
-        return _result
     }
 
     private static func compareTimeInterval(_ lhs: DispatchTimeInterval, _ rhs: DispatchTimeInterval) -> Bool {

--- a/Tests/ServiceDiscoveryTests/MapServiceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/MapServiceServiceDiscoveryTests.swift
@@ -89,25 +89,23 @@ class MapServiceServiceDiscoveryTests: XCTestCase {
 
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).mapService { (service: Int) in self.services[service] }
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 let _fooInstances = try await serviceDiscovery.lookup(self.computedFooService, deadline: nil)
 
                 XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(self.computedFooService)] to have 1 instance, got \(_fooInstances.count)")
                 XCTAssertEqual(_fooInstances, self.fooInstances, "Expected service[\(self.computedFooService)] to have instances \(self.fooInstances), got \(_fooInstances)")
-                expectation.fulfill()
             } catch {
                 XCTFail("Failed to lookup instances for service[\(self.computedFooService)]: \(error)")
             }
         }
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 let _barInstances = try await serviceDiscovery.lookup(self.computedBarService, deadline: nil)
 
                 XCTAssertEqual(_barInstances.count, 2, "Expected service[\(self.computedBarService)] to have 2 instances, got \(_barInstances.count)")
                 XCTAssertEqual(_barInstances, self.barInstances, "Expected service[\(self.computedBarService)] to have instances \(self.barInstances), got \(_barInstances)")
-                expectation.fulfill()
             } catch {
                 XCTFail("Failed to lookup instances for service[\(self.computedBarService)] \(error)")
             }
@@ -139,7 +137,7 @@ class MapServiceServiceDiscoveryTests: XCTestCase {
             return XCTFail("Expected LookupError.unknownService, got \(error)")
         }
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 _ = try await serviceDiscovery.lookup(unknownComputedService, deadline: nil)
                 XCTFail("Lookup instances for service[\(unknownComputedService)] should return an error")
@@ -147,7 +145,6 @@ class MapServiceServiceDiscoveryTests: XCTestCase {
                 guard let lookupError = error as? LookupError, case .unknownService = lookupError else {
                     return XCTFail("Expected LookupError.unknownService, got \(error)")
                 }
-                expectation.fulfill()
             }
         }
         #endif

--- a/Tests/ServiceDiscoveryTests/TypeErasedServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/TypeErasedServiceDiscoveryTests.swift
@@ -120,13 +120,12 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
         let boxedServiceDiscovery = AsyncServiceDiscoveryBox<Service, Instance>(serviceDiscovery)
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 let _fooInstances = try await boxedServiceDiscovery.lookup(self.fooService)
 
                 XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(self.fooService)] to have 1 instance, got \(_fooInstances.count)")
                 XCTAssertEqual(_fooInstances, self.fooInstances, "Expected service[\(self.fooService)] to have instances \(self.fooInstances), got \(_fooInstances)")
-                expectation.fulfill()
             } catch {
                 XCTFail("Failed to lookup instances for service[\(self.fooService)]: \(error)")
             }
@@ -294,13 +293,12 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
         let anyServiceDiscovery = AnyAsyncServiceDiscovery(serviceDiscovery)
 
-        runAsyncAndWaitFor { expectation in
+        runAsyncAndWaitFor {
             do {
                 let _fooInstances: [Instance] = try await anyServiceDiscovery.lookupAndUnwrap(self.fooService)
 
                 XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(self.fooService)] to have 1 instance, got \(_fooInstances.count)")
                 XCTAssertEqual(_fooInstances, self.fooInstances, "Expected service[\(self.fooService)] to have instances \(self.fooInstances), got \(_fooInstances)")
-                expectation.fulfill()
             } catch {
                 XCTFail("Failed to lookup instances for service[\(self.fooService)]: \(error)")
             }

--- a/Tests/ServiceDiscoveryTests/Utility.swift
+++ b/Tests/ServiceDiscoveryTests/Utility.swift
@@ -39,11 +39,13 @@ extension XCTestCase {
 
 #if compiler(>=5.5)
 extension XCTestCase {
+    // TODO: remove once XCTest supports async functions
     @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-    func runAsyncAndWaitFor(_ closure: @escaping (_ finished: XCTestExpectation) async -> Void, _ timeout: TimeInterval = 1.0) {
+    func runAsyncAndWaitFor(_ closure: @escaping () async -> Void, _ timeout: TimeInterval = 1.0) {
         let finished = expectation(description: "finished")
         detach {
-            await closure(finished)
+            await closure()
+            finished.fulfill()
         }
         wait(for: [finished], timeout: timeout)
     }

--- a/Tests/ServiceDiscoveryTests/Utility.swift
+++ b/Tests/ServiceDiscoveryTests/Utility.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftServiceDiscovery open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftServiceDiscovery project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftServiceDiscovery project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+
+@testable import ServiceDiscovery
+import XCTest
+
+extension XCTestCase {
+    func ensureResult<SD: ServiceDiscovery>(serviceDiscovery: SD, service: SD.Service) throws -> Result<[SD.Instance], Error> {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Result<[SD.Instance], Error>?
+
+        serviceDiscovery.lookup(service, deadline: nil) {
+            result = $0
+            semaphore.signal()
+        }
+
+        _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(1))
+
+        guard let _result = result else {
+            throw LookupError.timedOut
+        }
+
+        return _result
+    }
+}
+
+#if compiler(>=5.5)
+extension XCTestCase {
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    func runAsyncAndWaitFor(_ closure: @escaping (_ finished: XCTestExpectation) async -> Void, _ timeout: TimeInterval = 1.0) {
+        let finished = expectation(description: "finished")
+        detach {
+            await closure(finished)
+        }
+        wait(for: [finished], timeout: timeout)
+    }
+}
+#endif

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -7,6 +7,12 @@ services:
     build:
       args:
         base_image: "swiftlang/swift:nightly-main-focal"
+        
+  build:
+    image: swift-service-discovery:20.04-main
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+    command: /bin/bash -xcl "swift build -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} -Xswiftc -Xfrontend -Xswiftc -enable-experimental-concurrency"
 
   test:
     image: swift-service-discovery:20.04-main

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -26,6 +26,10 @@ services:
     <<: *common
     command: /bin/bash -xcl "./scripts/soundness.sh"
 
+  build:
+    <<: *common
+    command: /bin/bash -xcl "swift build -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
+
   test:
     <<: *common
     command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the SwiftServiceDiscovery open source project
 ##
-## Copyright (c) 2020 Apple Inc. and the SwiftServiceDiscovery project authors
+## Copyright (c) 2020-2021 Apple Inc. and the SwiftServiceDiscovery project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/2017-201[89]/YEARS/' -e 's/2019-2020/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/'
+    sed -e 's/2019-2020/YEARS/' -e 's/2019-2021/YEARS/' -e 's/2020-2021/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "


### PR DESCRIPTION
Motivation:
Async/await is coming in Swift 5.5.

Modifications:
Add `AsyncServiceDiscovery` protocol with async `lookup` method instead of callback and add conformance to existing service discovery implementations.

Result:
Async service discovery available in Swift 5.5.