### PR TITLE
A different approach to add async-await support

### DIFF
--- a/Sources/ServiceDiscovery/ServiceDiscovery+AsyncAwait.swift
+++ b/Sources/ServiceDiscovery/ServiceDiscovery+AsyncAwait.swift
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftServiceDiscovery open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftServiceDiscovery project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftServiceDiscovery project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+public extension ServiceDiscovery {
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func lookup(_ service: Service, deadline: DispatchTime? = nil) async throws -> [Instance] {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[Instance], Error>) in
+            self.lookup(service, deadline: deadline) { result in
+                switch result {
+                case .success(let instances):
+                    continuation.resume(returning: instances)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func subscribe(to service: Service) -> ServiceSnapshots<Instance> {
+        ServiceSnapshots(AsyncThrowingStream<[Instance], Error> { continuation in
+            Task {
+                let cancellationToken = self.subscribe(
+                    to: service,
+                    onNext: { result in
+                        switch result {
+                        case .success(let instances):
+                            continuation.yield(instances)
+                        case .failure(let error):
+                            // LookupError is recoverable (e.g., service is added *after* subscription begins), so don't give up yet
+                            guard error is LookupError else {
+                                return continuation.finish(throwing: error)
+                            }
+                        }
+                    },
+                    onComplete: { reason in
+                        switch reason {
+                        case .cancellationRequested:
+                            continuation.finish()
+                        case .serviceDiscoveryUnavailable:
+                            continuation.finish(throwing: ServiceDiscoveryError.unavailable)
+                        default:
+                            continuation.finish(throwing: ServiceDiscoveryError.other(reason.description))
+                        }
+                    }
+                )
+
+                continuation.onTermination = { @Sendable (_) -> Void in
+                    cancellationToken.cancel()
+                }
+            }
+        })
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public struct ServiceSnapshots<Instance>: AsyncSequence, AsyncIteratorProtocol {
+    public typealias Element = [Instance]
+
+    private let _next: () async throws -> [Instance]?
+
+    public init<SnapshotSequence: AsyncSequence>(_ snapshots: SnapshotSequence) where SnapshotSequence.Element == Element {
+        var iterator = snapshots.makeAsyncIterator()
+        self._next = { try await iterator.next() }
+    }
+
+    public func next() async throws -> [Instance]? {
+        try await self._next()
+    }
+
+    public func makeAsyncIterator() -> Self {
+        self
+    }
+}
+
+#endif

--- a/Sources/ServiceDiscovery/ServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/ServiceDiscovery.swift
@@ -159,11 +159,14 @@ public struct LookupError: Error, Equatable, CustomStringConvertible {
 public struct ServiceDiscoveryError: Error, Equatable, CustomStringConvertible {
     internal enum ErrorType: Equatable, CustomStringConvertible {
         case unavailable
+        case other(String)
 
         var description: String {
             switch self {
             case .unavailable:
                 return "unavailable"
+            case .other(let detail):
+                return "other: \(detail)"
             }
         }
     }
@@ -176,4 +179,8 @@ public struct ServiceDiscoveryError: Error, Equatable, CustomStringConvertible {
 
     /// `ServiceDiscovery` instance is unavailable.
     public static let unavailable = ServiceDiscoveryError(type: .unavailable)
+
+    public static func other(_ detail: String) -> ServiceDiscoveryError {
+        ServiceDiscoveryError(type: .other(detail))
+    }
 }

--- a/Tests/ServiceDiscoveryTests/FilterInstanceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/FilterInstanceServiceDiscoveryTests.swift
@@ -257,14 +257,10 @@ class FilterInstanceServiceDiscoveryTests: XCTestCase {
     }
 
     func testThrownErrorsPropagateIntoFailures() throws {
-        enum TestError: Error {
-            case error
-        }
-
         let configuration = InMemoryServiceDiscovery.Configuration(serviceInstances: [fooService: self.fooBaseInstances])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).filterInstance { _ in throw TestError.error }
 
-        let result = try self.ensureResult(serviceDiscovery: serviceDiscovery, service: self.fooService)
+        let result = try ensureResult(serviceDiscovery: serviceDiscovery, service: self.fooService)
         guard case .failure(let err) = result else {
             XCTFail("Expected failure, got \(result)")
             return
@@ -275,45 +271,107 @@ class FilterInstanceServiceDiscoveryTests: XCTestCase {
     func testPropagateDefaultTimeout() throws {
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: ["foo-service": []])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).filterInstance { $0.port == 7001 }
-        XCTAssertTrue(Self.compareTimeInterval(configuration.defaultLookupTimeout, serviceDiscovery.defaultLookupTimeout), "\(configuration.defaultLookupTimeout) does not match \(serviceDiscovery.defaultLookupTimeout)")
+        XCTAssertTrue(compareTimeInterval(configuration.defaultLookupTimeout, serviceDiscovery.defaultLookupTimeout), "\(configuration.defaultLookupTimeout) does not match \(serviceDiscovery.defaultLookupTimeout)")
     }
 
-    private func ensureResult<SD: ServiceDiscovery>(serviceDiscovery: SD, service: SD.Service) throws -> Result<[SD.Instance], Error> {
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<[SD.Instance], Error>?
+    // MARK: - async/await API tests
 
-        serviceDiscovery.lookup(service, deadline: nil) {
-            result = $0
-            semaphore.signal()
+    func test_async_lookup() throws {
+        #if !(compiler(>=5.5) && canImport(_Concurrency))
+        try XCTSkipIf(true)
+        #else
+        var configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [fooService: self.fooBaseInstances])
+        configuration.register(service: self.barService, instances: self.barBaseInstances)
+
+        let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).filterInstance { [7001, 9001, 9002].contains($0.port) }
+
+        runAsyncAndWaitFor {
+            let _fooInstances = try await serviceDiscovery.lookup(self.fooService)
+            XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(self.fooService)] to have 1 instance, got \(_fooInstances.count)")
+            XCTAssertEqual(_fooInstances, self.fooDerivedInstances, "Expected service[\(self.fooService)] to have instances \(self.fooDerivedInstances), got \(_fooInstances)")
+
+            let _barInstances = try await serviceDiscovery.lookup(self.barService)
+            XCTAssertEqual(_barInstances.count, 2, "Expected service[\(self.barService)] to have 2 instances, got \(_barInstances.count)")
+            XCTAssertEqual(_barInstances, self.barDerivedInstances, "Expected service[\(self.barService)] to have instances \(self.barDerivedInstances), got \(_barInstances)")
+        }
+        #endif
+    }
+
+    func test_async_lookup_errorIfServiceUnknown() throws {
+        #if !(compiler(>=5.5) && canImport(_Concurrency))
+        try XCTSkipIf(true)
+        #else
+        let unknownService = "unknown-service"
+
+        let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: ["foo-service": []])
+        let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).filterInstance { $0.port == 7001 }
+
+        runAsyncAndWaitFor {
+            do {
+                _ = try await serviceDiscovery.lookup(unknownService)
+                return XCTFail("Lookup instances for service[\(unknownService)] should return an error")
+            } catch {
+                guard let lookupError = error as? LookupError, lookupError == .unknownService else {
+                    return XCTFail("Expected LookupError.unknownService, got \(error)")
+                }
+            }
+        }
+        #endif
+    }
+
+    func test_async_subscribe() throws {
+        #if !(compiler(>=5.5) && canImport(_Concurrency))
+        try XCTSkipIf(true)
+        #else
+        let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [fooService: self.fooBaseInstances])
+        let baseServiceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
+        let serviceDiscovery = baseServiceDiscovery.filterInstance { [7001, 9001, 9002].contains($0.port) }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        let counter = ManagedAtomic<Int>(0)
+
+        Task.detached {
+            // Allow time for subscription to start
+            usleep(100_000)
+            // Update #1
+            baseServiceDiscovery.register(self.barService, instances: [])
+            usleep(50000)
+            // Update #2
+            baseServiceDiscovery.register(self.barService, instances: self.barBaseInstances)
+        }
+
+        let task = Task.detached { () -> Void in
+            do {
+                for try await instances in serviceDiscovery.subscribe(to: self.barService) {
+                    switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {
+                    case 1:
+                        XCTAssertEqual(instances, [], "Expected instances of \(self.barService) to be empty, got \(instances)")
+                    case 2:
+                        XCTAssertEqual(instances, self.barDerivedInstances, "Expected instances of \(self.barService) to be \(self.barDerivedInstances), got \(instances)")
+                        // This causes the stream to terminate
+                        baseServiceDiscovery.shutdown()
+                    default:
+                        XCTFail("Expected to receive instances 2 times")
+                    }
+                }
+            } catch {
+                switch counter.load(ordering: .relaxed) {
+                case 2: // shutdown is called after receiving two results
+                    guard let serviceDiscoveryError = error as? ServiceDiscoveryError, serviceDiscoveryError == .unavailable else {
+                        return XCTFail("Expected ServiceDiscoveryError.unavailable, got \(error)")
+                    }
+                    // Test is complete at this point
+                    semaphore.signal()
+                default:
+                    XCTFail("Unexpected error \(error)")
+                }
+            }
         }
 
         _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(1))
+        task.cancel()
 
-        guard let _result = result else {
-            throw LookupError.timedOut
-        }
-
-        return _result
-    }
-
-    private static func compareTimeInterval(_ lhs: DispatchTimeInterval, _ rhs: DispatchTimeInterval) -> Bool {
-        switch (lhs, rhs) {
-        case (.seconds(let lhs), .seconds(let rhs)):
-            return lhs == rhs
-        case (.milliseconds(let lhs), .milliseconds(let rhs)):
-            return lhs == rhs
-        case (.microseconds(let lhs), .microseconds(let rhs)):
-            return lhs == rhs
-        case (.nanoseconds(let lhs), .nanoseconds(let rhs)):
-            return lhs == rhs
-        case (.never, .never):
-            return true
-        case (.seconds, _), (.milliseconds, _), (.microseconds, _), (.nanoseconds, _), (.never, _):
-            return false
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        @unknown default:
-            return false
+        XCTAssertEqual(counter.load(ordering: .relaxed), 2, "Expected to receive instances 2 times, got \(counter.load(ordering: .relaxed)) times")
         #endif
-        }
     }
 }

--- a/Tests/ServiceDiscoveryTests/Helpers.swift
+++ b/Tests/ServiceDiscoveryTests/Helpers.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftServiceDiscovery open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftServiceDiscovery project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftServiceDiscovery project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import ServiceDiscovery
+import XCTest
+
+enum TestError: Error {
+    case error
+}
+
+func compareTimeInterval(_ lhs: DispatchTimeInterval, _ rhs: DispatchTimeInterval) -> Bool {
+    switch (lhs, rhs) {
+    case (.seconds(let lhs), .seconds(let rhs)):
+        return lhs == rhs
+    case (.milliseconds(let lhs), .milliseconds(let rhs)):
+        return lhs == rhs
+    case (.microseconds(let lhs), .microseconds(let rhs)):
+        return lhs == rhs
+    case (.nanoseconds(let lhs), .nanoseconds(let rhs)):
+        return lhs == rhs
+    case (.never, .never):
+        return true
+    case (.seconds, _), (.milliseconds, _), (.microseconds, _), (.nanoseconds, _), (.never, _):
+        return false
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    @unknown default:
+        return false
+    #endif
+    }
+}
+
+func ensureResult<SD: ServiceDiscovery>(serviceDiscovery: SD, service: SD.Service) throws -> Result<[SD.Instance], Error> {
+    let semaphore = DispatchSemaphore(value: 0)
+    var result: Result<[SD.Instance], Error>?
+
+    serviceDiscovery.lookup(service, deadline: nil) {
+        result = $0
+        semaphore.signal()
+    }
+
+    _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(1))
+
+    guard let _result = result else {
+        throw LookupError.timedOut
+    }
+
+    return _result
+}
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension XCTestCase {
+    // TODO: remove once XCTest supports async functions
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    func runAsyncAndWaitFor(_ closure: @escaping @Sendable () async throws -> Void, _ timeout: TimeInterval = 1.0) {
+        let finished = expectation(description: "finished")
+        Task.detached {
+            try await closure()
+            finished.fulfill()
+        }
+        wait(for: [finished], timeout: timeout)
+    }
+}
+#endif

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -12,6 +12,7 @@ services:
     image: swift-service-discovery:20.04-main
     environment: []
       #- SANITIZER_ARG=--sanitize=thread
+    command: /bin/bash -xcl "swift test $${SANITIZER_ARG-}" # Disable -warnings-as-errors due to Sendable warnings
 
   shell:
     image: swift-service-discovery:20.04-main


### PR DESCRIPTION
Unlike https://github.com/apple/swift-service-discovery/pull/38, this
doesn't require Swift 5.5.