### PR TITLE
Less racy InMemoryServiceDiscovery

### DIFF
--- a/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
@@ -218,4 +218,3 @@ private extension NSLock {
         return try body()
     }
 }
-


### PR DESCRIPTION
`InMemoryServiceDiscovery` is used in tests quite extensively. To be able to assert on certain conditions we must ensure that `InMemoryServiceDiscovery` subscription behavior is predictable. Currently `InMemoryServiceDiscovery` uses two locks `serviceInstancesLock` and `serviceSubscriptionsLock`, which are not synchronized. If you subscribe to a `Service` this leads to an at least once invocation of your subscription callback. To ensure correct testing, we should have an exactly once behavior here. This patch changes the internal workings to use a single lock in order to ensure exactly once invocation of the provided callback.