### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Async APIs are available for Swift 5.5 and above.
 To fetch the current list of instances:
                                             
 ```swift
-let instances: [Instace] = try await serviceDiscovery.lookup(service)
+let instances: [Instance] = try await serviceDiscovery.lookup(service)
 ```
    
 To fetch the current list of instances **AND** subscribe to future changes:

--- a/Sources/ServiceDiscovery/Docs.docc/index.md
+++ b/Sources/ServiceDiscovery/Docs.docc/index.md
@@ -79,7 +79,7 @@ Async APIs are available for Swift 5.5 and above.
 To fetch the current list of instances:
                                             
 ```swift
-let instances: [Instace] = try await serviceDiscovery.lookup(service)
+let instances: [Instance] = try await serviceDiscovery.lookup(service)
 ```
    
 To fetch the current list of instances **AND** subscribe to future changes:


### PR DESCRIPTION
This fixes a minor typo in the `README.md` and DocC documentation.