### PR TITLE
Test cleanup

### DIFF
--- a/Sources/ServiceDiscovery/ServiceDiscovery+AsyncAwait.swift
+++ b/Sources/ServiceDiscovery/ServiceDiscovery+AsyncAwait.swift
@@ -73,7 +73,7 @@ public extension ServiceDiscovery {
                 }
             )
 
-            continuation.onTermination = { @Sendable (_) -> Void in
+            continuation.onTermination = { @Sendable (_) in
                 cancellationToken.cancel()
             }
         })

--- a/Sources/ServiceDiscovery/ServiceDiscovery+Combinators.swift
+++ b/Sources/ServiceDiscovery/ServiceDiscovery+Combinators.swift
@@ -27,8 +27,10 @@ public extension ServiceDiscovery {
     /// the derived function.
     ///
     /// It is not necessarily safe to block in this closure. This closure should not block for safety.
-    func mapService<ComputedService: Hashable>(serviceType: ComputedService.Type = ComputedService.self,
-                                               _ transformer: @escaping (ComputedService) throws -> Service) -> MapServiceServiceDiscovery<Self, ComputedService> {
+    func mapService<ComputedService: Hashable>(
+        serviceType: ComputedService.Type = ComputedService.self,
+        _ transformer: @escaping (ComputedService) throws -> Service
+    ) -> MapServiceServiceDiscovery<Self, ComputedService> {
         MapServiceServiceDiscovery(originalSD: self, transformer: transformer)
     }
 

--- a/Tests/ServiceDiscoveryTests/AsyncAwaitTests.swift
+++ b/Tests/ServiceDiscoveryTests/AsyncAwaitTests.swift
@@ -62,7 +62,7 @@ final class AsyncAwaitTests: XCTestCase {
 
             // Wait for task group to be cancelled and cancelCounter is incremented
             repeat {
-                try await Task.sleep(for: .milliseconds(10))
+                try await Task.sleep(nanoseconds: 10_000_000)
             } while !taskGroup.isCancelled
 
             XCTAssertEqual(discoveryService.cancelCounter.load(ordering: .relaxed), 1)

--- a/Tests/ServiceDiscoveryTests/FilterInstanceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/FilterInstanceServiceDiscoveryTests.swift
@@ -324,7 +324,7 @@ class FilterInstanceServiceDiscoveryTests: XCTestCase {
             baseServiceDiscovery.register(Self.barService, instances: Self.barBaseInstances)
         }
 
-        let task = Task { () in
+        let task = Task<Void, Error> { () in
             do {
                 for try await instances in serviceDiscovery.subscribe(to: Self.barService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {

--- a/Tests/ServiceDiscoveryTests/FilterInstanceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/FilterInstanceServiceDiscoveryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2020-2023 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2020-2024 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -276,64 +276,45 @@ class FilterInstanceServiceDiscoveryTests: XCTestCase {
 
     // MARK: - async/await API tests
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_async_lookup() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_async_lookup() async throws {
         var configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [Self.fooService: Self.fooBaseInstances])
         configuration.register(service: Self.barService, instances: Self.barBaseInstances)
 
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).filterInstance { [7001, 9001, 9002].contains($0.port) }
 
-        runAsyncAndWaitFor {
-            let _fooInstances = try await serviceDiscovery.lookup(Self.fooService)
-            XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(Self.fooService)] to have 1 instance, got \(_fooInstances.count)")
-            XCTAssertEqual(_fooInstances, Self.fooDerivedInstances, "Expected service[\(Self.fooService)] to have instances \(Self.fooDerivedInstances), got \(_fooInstances)")
+        let _fooInstances = try await serviceDiscovery.lookup(Self.fooService)
+        XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(Self.fooService)] to have 1 instance, got \(_fooInstances.count)")
+        XCTAssertEqual(_fooInstances, Self.fooDerivedInstances, "Expected service[\(Self.fooService)] to have instances \(Self.fooDerivedInstances), got \(_fooInstances)")
 
-            let _barInstances = try await serviceDiscovery.lookup(Self.barService)
-            XCTAssertEqual(_barInstances.count, 2, "Expected service[\(Self.barService)] to have 2 instances, got \(_barInstances.count)")
-            XCTAssertEqual(_barInstances, Self.barDerivedInstances, "Expected service[\(Self.barService)] to have instances \(Self.barDerivedInstances), got \(_barInstances)")
-        }
-        #endif
+        let _barInstances = try await serviceDiscovery.lookup(Self.barService)
+        XCTAssertEqual(_barInstances.count, 2, "Expected service[\(Self.barService)] to have 2 instances, got \(_barInstances.count)")
+        XCTAssertEqual(_barInstances, Self.barDerivedInstances, "Expected service[\(Self.barService)] to have instances \(Self.barDerivedInstances), got \(_barInstances)")
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_async_lookup_errorIfServiceUnknown() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_async_lookup_errorIfServiceUnknown() async throws {
         let unknownService = "unknown-service"
 
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: ["foo-service": []])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).filterInstance { $0.port == 7001 }
 
-        runAsyncAndWaitFor {
-            do {
-                _ = try await serviceDiscovery.lookup(unknownService)
-                return XCTFail("Lookup instances for service[\(unknownService)] should return an error")
-            } catch {
-                guard let lookupError = error as? LookupError, lookupError == .unknownService else {
-                    return XCTFail("Expected LookupError.unknownService, got \(error)")
-                }
+        do {
+            _ = try await serviceDiscovery.lookup(unknownService)
+            return XCTFail("Lookup instances for service[\(unknownService)] should return an error")
+        } catch {
+            guard let lookupError = error as? LookupError, lookupError == .unknownService else {
+                return XCTFail("Expected LookupError.unknownService, got \(error)")
             }
         }
-        #endif
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_async_subscribe() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_async_subscribe() async throws {
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [Self.fooService: Self.fooBaseInstances])
         let baseServiceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
         let serviceDiscovery = baseServiceDiscovery.filterInstance { [7001, 9001, 9002].contains($0.port) }
 
-        let semaphore = DispatchSemaphore(value: 0)
         let counter = ManagedAtomic<Int>(0)
 
-        Task.detached {
+        Task {
             // Allow time for subscription to start
             usleep(100_000)
             // Update #1
@@ -343,7 +324,7 @@ class FilterInstanceServiceDiscoveryTests: XCTestCase {
             baseServiceDiscovery.register(Self.barService, instances: Self.barBaseInstances)
         }
 
-        let task = Task.detached { () -> Void in
+        let task = Task { () in
             do {
                 for try await instances in serviceDiscovery.subscribe(to: Self.barService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {
@@ -363,18 +344,15 @@ class FilterInstanceServiceDiscoveryTests: XCTestCase {
                     guard let serviceDiscoveryError = error as? ServiceDiscoveryError, serviceDiscoveryError == .unavailable else {
                         return XCTFail("Expected ServiceDiscoveryError.unavailable, got \(error)")
                     }
-                    // Test is complete at this point
-                    semaphore.signal()
+                // Test is complete at this point
                 default:
                     XCTFail("Unexpected error \(error)")
                 }
             }
         }
 
-        _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(1))
-        task.cancel()
+        _ = await task.result
 
         XCTAssertEqual(counter.load(ordering: .relaxed), 2, "Expected to receive instances 2 times, got \(counter.load(ordering: .relaxed)) times")
-        #endif
     }
 }

--- a/Tests/ServiceDiscoveryTests/Helpers.swift
+++ b/Tests/ServiceDiscoveryTests/Helpers.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2021 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2021-2024 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -58,18 +58,3 @@ func ensureResult<SD: ServiceDiscovery>(serviceDiscovery: SD, service: SD.Servic
 
     return _result
 }
-
-#if compiler(>=5.5) && canImport(_Concurrency)
-extension XCTestCase {
-    // TODO: remove once XCTest supports async functions
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func runAsyncAndWaitFor(_ closure: @escaping @Sendable () async throws -> Void, _ timeout: TimeInterval = 1.0) {
-        let finished = expectation(description: "finished")
-        Task.detached {
-            try await closure()
-            finished.fulfill()
-        }
-        wait(for: [finished], timeout: timeout)
-    }
-}
-#endif

--- a/Tests/ServiceDiscoveryTests/InMemoryServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/InMemoryServiceDiscoveryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2019-2023 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2019-2024 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -245,63 +245,44 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
 
     // MARK: - async/await API tests
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_async_lookup() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_async_lookup() async throws {
         var configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [Self.fooService: Self.fooInstances])
         configuration.register(service: Self.barService, instances: Self.barInstances)
 
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
 
-        runAsyncAndWaitFor {
-            let _fooInstances = try await serviceDiscovery.lookup(Self.fooService)
-            XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(Self.fooService)] to have 1 instance, got \(_fooInstances.count)")
-            XCTAssertEqual(_fooInstances, Self.fooInstances, "Expected service[\(Self.fooService)] to have instances \(Self.fooInstances), got \(_fooInstances)")
+        let _fooInstances = try await serviceDiscovery.lookup(Self.fooService)
+        XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(Self.fooService)] to have 1 instance, got \(_fooInstances.count)")
+        XCTAssertEqual(_fooInstances, Self.fooInstances, "Expected service[\(Self.fooService)] to have instances \(Self.fooInstances), got \(_fooInstances)")
 
-            let _barInstances = try await serviceDiscovery.lookup(Self.barService)
-            XCTAssertEqual(_barInstances.count, 2, "Expected service[\(Self.barService)] to have 2 instances, got \(_barInstances.count)")
-            XCTAssertEqual(_barInstances, Self.barInstances, "Expected service[\(Self.barService)] to have instances \(Self.barInstances), got \(_barInstances)")
-        }
-        #endif
+        let _barInstances = try await serviceDiscovery.lookup(Self.barService)
+        XCTAssertEqual(_barInstances.count, 2, "Expected service[\(Self.barService)] to have 2 instances, got \(_barInstances.count)")
+        XCTAssertEqual(_barInstances, Self.barInstances, "Expected service[\(Self.barService)] to have instances \(Self.barInstances), got \(_barInstances)")
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_async_lookup_errorIfServiceUnknown() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_async_lookup_errorIfServiceUnknown() async throws {
         let unknownService = "unknown-service"
 
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: ["foo-service": []])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
 
-        runAsyncAndWaitFor {
-            do {
-                _ = try await serviceDiscovery.lookup(unknownService)
-                return XCTFail("Lookup instances for service[\(unknownService)] should return an error")
-            } catch {
-                guard let lookupError = error as? LookupError, lookupError == .unknownService else {
-                    return XCTFail("Expected LookupError.unknownService, got \(error)")
-                }
+        do {
+            _ = try await serviceDiscovery.lookup(unknownService)
+            return XCTFail("Lookup instances for service[\(unknownService)] should return an error")
+        } catch {
+            guard let lookupError = error as? LookupError, lookupError == .unknownService else {
+                return XCTFail("Expected LookupError.unknownService, got \(error)")
             }
         }
-        #endif
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_async_subscribe() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_async_subscribe() async throws {
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [Self.fooService: Self.fooInstances])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
 
-        let semaphore = DispatchSemaphore(value: 0)
         let counter = ManagedAtomic<Int>(0)
 
-        Task.detached {
+        Task {
             // Allow time for subscription to start
             usleep(100_000)
             // Update #1
@@ -311,7 +292,7 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
             serviceDiscovery.register(Self.barService, instances: Self.barInstances)
         }
 
-        let task = Task.detached { () -> Void in
+        let task = Task { () in
             do {
                 for try await instances in serviceDiscovery.subscribe(to: Self.barService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {
@@ -331,18 +312,15 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
                     guard let serviceDiscoveryError = error as? ServiceDiscoveryError, serviceDiscoveryError == .unavailable else {
                         return XCTFail("Expected ServiceDiscoveryError.unavailable, got \(error)")
                     }
-                    // Test is complete at this point
-                    semaphore.signal()
+                // Test is complete at this point
                 default:
                     XCTFail("Unexpected error \(error)")
                 }
             }
         }
 
-        _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(1))
-        task.cancel()
+        _ = await task.result
 
         XCTAssertEqual(counter.load(ordering: .relaxed), 2, "Expected to receive instances 2 times, got \(counter.load(ordering: .relaxed)) times")
-        #endif
     }
 }

--- a/Tests/ServiceDiscoveryTests/InMemoryServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/InMemoryServiceDiscoveryTests.swift
@@ -292,7 +292,7 @@ class InMemoryServiceDiscoveryTests: XCTestCase {
             serviceDiscovery.register(Self.barService, instances: Self.barInstances)
         }
 
-        let task = Task { () in
+        let task = Task<Void, Error> { () in
             do {
                 for try await instances in serviceDiscovery.subscribe(to: Self.barService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {

--- a/Tests/ServiceDiscoveryTests/MapInstanceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/MapInstanceServiceDiscoveryTests.swift
@@ -311,7 +311,6 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
         let baseServiceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
         let serviceDiscovery = baseServiceDiscovery.mapInstance { port in HostPort(host: "localhost", port: port) }
 
-        let semaphore = DispatchSemaphore(value: 0)
         let counter = ManagedAtomic<Int>(0)
 
         Task {

--- a/Tests/ServiceDiscoveryTests/MapInstanceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/MapInstanceServiceDiscoveryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2019-2023 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2019-2024 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -275,56 +275,38 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
 
     // MARK: - async/await API tests
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_async_lookup() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_async_lookup() async throws {
         var configuration = InMemoryServiceDiscovery<Service, BaseInstance>.Configuration(serviceInstances: [Self.fooService: Self.fooBaseInstances])
         configuration.register(service: Self.barService, instances: Self.barBaseInstances)
 
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).mapInstance { port in HostPort(host: "localhost", port: port) }
 
-        runAsyncAndWaitFor {
-            let _fooInstances = try await serviceDiscovery.lookup(Self.fooService)
-            XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(Self.fooService)] to have 1 instance, got \(_fooInstances.count)")
-            XCTAssertEqual(_fooInstances, Self.fooDerivedInstances, "Expected service[\(Self.fooService)] to have instances \(Self.fooDerivedInstances), got \(_fooInstances)")
+        let _fooInstances = try await serviceDiscovery.lookup(Self.fooService)
+        XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(Self.fooService)] to have 1 instance, got \(_fooInstances.count)")
+        XCTAssertEqual(_fooInstances, Self.fooDerivedInstances, "Expected service[\(Self.fooService)] to have instances \(Self.fooDerivedInstances), got \(_fooInstances)")
 
-            let _barInstances = try await serviceDiscovery.lookup(Self.barService)
-            XCTAssertEqual(_barInstances.count, 2, "Expected service[\(Self.barService)] to have 2 instances, got \(_barInstances.count)")
-            XCTAssertEqual(_barInstances, Self.barDerivedInstances, "Expected service[\(Self.barService)] to have instances \(Self.barDerivedInstances), got \(_barInstances)")
-        }
-        #endif
+        let _barInstances = try await serviceDiscovery.lookup(Self.barService)
+        XCTAssertEqual(_barInstances.count, 2, "Expected service[\(Self.barService)] to have 2 instances, got \(_barInstances.count)")
+        XCTAssertEqual(_barInstances, Self.barDerivedInstances, "Expected service[\(Self.barService)] to have instances \(Self.barDerivedInstances), got \(_barInstances)")
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_async_lookup_errorIfServiceUnknown() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_async_lookup_errorIfServiceUnknown() async throws {
         let unknownService = "unknown-service"
 
         let configuration = InMemoryServiceDiscovery<Service, BaseInstance>.Configuration(serviceInstances: ["foo-service": []])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).mapInstance { port in HostPort(host: "localhost", port: port) }
 
-        runAsyncAndWaitFor {
-            do {
-                _ = try await serviceDiscovery.lookup(unknownService)
-                return XCTFail("Lookup instances for service[\(unknownService)] should return an error")
-            } catch {
-                guard let lookupError = error as? LookupError, lookupError == .unknownService else {
-                    return XCTFail("Expected LookupError.unknownService, got \(error)")
-                }
+        do {
+            _ = try await serviceDiscovery.lookup(unknownService)
+            return XCTFail("Lookup instances for service[\(unknownService)] should return an error")
+        } catch {
+            guard let lookupError = error as? LookupError, lookupError == .unknownService else {
+                return XCTFail("Expected LookupError.unknownService, got \(error)")
             }
         }
-        #endif
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_async_subscribe() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_async_subscribe() async throws {
         let configuration = InMemoryServiceDiscovery<Service, BaseInstance>.Configuration(serviceInstances: [Self.fooService: Self.fooBaseInstances])
         let baseServiceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
         let serviceDiscovery = baseServiceDiscovery.mapInstance { port in HostPort(host: "localhost", port: port) }
@@ -332,7 +314,7 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
         let semaphore = DispatchSemaphore(value: 0)
         let counter = ManagedAtomic<Int>(0)
 
-        Task.detached {
+        Task {
             // Allow time for subscription to start
             usleep(100_000)
             // Update #1
@@ -342,7 +324,7 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
             baseServiceDiscovery.register(Self.barService, instances: Self.barBaseInstances)
         }
 
-        let task = Task.detached { () -> Void in
+        let task = Task { () in
             do {
                 for try await instances in serviceDiscovery.subscribe(to: Self.barService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {
@@ -362,18 +344,15 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
                     guard let serviceDiscoveryError = error as? ServiceDiscoveryError, serviceDiscoveryError == .unavailable else {
                         return XCTFail("Expected ServiceDiscoveryError.unavailable, got \(error)")
                     }
-                    // Test is complete at this point
-                    semaphore.signal()
+                // Test is complete at this point
                 default:
                     XCTFail("Unexpected error \(error)")
                 }
             }
         }
 
-        _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(1))
-        task.cancel()
+        _ = await task.result
 
         XCTAssertEqual(counter.load(ordering: .relaxed), 2, "Expected to receive instances 2 times, got \(counter.load(ordering: .relaxed)) times")
-        #endif
     }
 }

--- a/Tests/ServiceDiscoveryTests/MapInstanceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/MapInstanceServiceDiscoveryTests.swift
@@ -323,7 +323,7 @@ class MapInstanceServiceDiscoveryTests: XCTestCase {
             baseServiceDiscovery.register(Self.barService, instances: Self.barBaseInstances)
         }
 
-        let task = Task { () in
+        let task = Task<Void, Error> { () in
             do {
                 for try await instances in serviceDiscovery.subscribe(to: Self.barService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {

--- a/Tests/ServiceDiscoveryTests/MapServiceServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/MapServiceServiceDiscoveryTests.swift
@@ -352,7 +352,7 @@ class MapServiceServiceDiscoveryTests: XCTestCase {
             baseServiceDiscovery.register(Self.barService, instances: Self.barInstances)
         }
 
-        let task = Task { () in
+        let task = Task<Void, Error> { () in
             do {
                 for try await instances in serviceDiscovery.subscribe(to: Self.computedBarService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {
@@ -388,7 +388,7 @@ class MapServiceServiceDiscoveryTests: XCTestCase {
         let configuration = InMemoryServiceDiscovery.Configuration(serviceInstances: [Self.fooService: Self.fooInstances])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration).mapService { (_: Int) -> String in throw TestError.error }
 
-        let task = Task { () in
+        let task = Task<Void, Error> { () in
             do {
                 for try await instances in serviceDiscovery.subscribe(to: Self.computedFooService) {
                     XCTFail("Expected error, got \(instances)")

--- a/Tests/ServiceDiscoveryTests/TypeErasedServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/TypeErasedServiceDiscoveryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftServiceDiscovery open source project
 //
-// Copyright (c) 2020-2023 Apple Inc. and the SwiftServiceDiscovery project authors
+// Copyright (c) 2020-2024 Apple Inc. and the SwiftServiceDiscovery project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -141,7 +141,7 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
         // Result #2: Later we register bar-service and that should notify the subscriber
         anyServiceDiscovery.subscribeAndUnwrap(
             to: Self.barService,
-            onNext: { (result: Result<[Instance], Error>) -> Void in
+            onNext: { (result: Result<[Instance], Error>) in
                 resultCounter.wrappingIncrement(ordering: .relaxed)
 
                 guard resultCounter.load(ordering: .relaxed) <= 2 else {
@@ -182,36 +182,24 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
 
     // MARK: - async/await API tests
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_ServiceDiscoveryBox_async_lookup() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_ServiceDiscoveryBox_async_lookup() async throws {
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [Self.fooService: Self.fooInstances])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
         let boxedServiceDiscovery = ServiceDiscoveryBox<Service, Instance>(serviceDiscovery)
 
-        runAsyncAndWaitFor {
-            let _fooInstances = try await boxedServiceDiscovery.lookup(Self.fooService)
-            XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(Self.fooService)] to have 1 instance, got \(_fooInstances.count)")
-            XCTAssertEqual(_fooInstances, Self.fooInstances, "Expected service[\(Self.fooService)] to have instances \(Self.fooInstances), got \(_fooInstances)")
-        }
-        #endif
+        let _fooInstances = try await boxedServiceDiscovery.lookup(Self.fooService)
+        XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(Self.fooService)] to have 1 instance, got \(_fooInstances.count)")
+        XCTAssertEqual(_fooInstances, Self.fooInstances, "Expected service[\(Self.fooService)] to have instances \(Self.fooInstances), got \(_fooInstances)")
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_ServiceDiscoveryBox_async_subscribe() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_ServiceDiscoveryBox_async_subscribe() async throws {
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [Self.fooService: Self.fooInstances])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
         let boxedServiceDiscovery = ServiceDiscoveryBox<Service, Instance>(serviceDiscovery)
 
-        let semaphore = DispatchSemaphore(value: 0)
         let counter = ManagedAtomic<Int>(0)
 
-        Task.detached {
+        Task {
             // Allow time for subscription to start
             usleep(100_000)
             // Update #1
@@ -221,7 +209,7 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
             serviceDiscovery.register(Self.barService, instances: Self.barInstances)
         }
 
-        let task = Task.detached { () -> Void in
+        let task = Task { () in
             do {
                 for try await instances in boxedServiceDiscovery.subscribe(to: Self.barService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {
@@ -241,51 +229,36 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
                     guard let serviceDiscoveryError = error as? ServiceDiscoveryError, serviceDiscoveryError == .unavailable else {
                         return XCTFail("Expected ServiceDiscoveryError.unavailable, got \(error)")
                     }
-                    // Test is complete at this point
-                    semaphore.signal()
+                // Test is complete at this point
                 default:
                     XCTFail("Unexpected error \(error)")
                 }
             }
         }
 
-        _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(1))
-        task.cancel()
+        _ = await task.result
 
         XCTAssertEqual(counter.load(ordering: .relaxed), 2, "Expected to receive instances 2 times, got \(counter.load(ordering: .relaxed)) times")
-        #endif
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_AnyServiceDiscovery_async_lookup() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_AnyServiceDiscovery_async_lookup() async throws {
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [Self.fooService: Self.fooInstances])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
         let anyServiceDiscovery = AnyServiceDiscovery(serviceDiscovery)
 
-        runAsyncAndWaitFor {
-            let _fooInstances: [Instance] = try await anyServiceDiscovery.lookupAndUnwrap(Self.fooService)
-            XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(Self.fooService)] to have 1 instance, got \(_fooInstances.count)")
-            XCTAssertEqual(_fooInstances, Self.fooInstances, "Expected service[\(Self.fooService)] to have instances \(Self.fooInstances), got \(_fooInstances)")
-        }
-        #endif
+        let _fooInstances: [Instance] = try await anyServiceDiscovery.lookupAndUnwrap(Self.fooService)
+        XCTAssertEqual(_fooInstances.count, 1, "Expected service[\(Self.fooService)] to have 1 instance, got \(_fooInstances.count)")
+        XCTAssertEqual(_fooInstances, Self.fooInstances, "Expected service[\(Self.fooService)] to have instances \(Self.fooInstances), got \(_fooInstances)")
     }
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func test_AnyServiceDiscovery_async_subscribe() throws {
-        #if !(compiler(>=5.5) && canImport(_Concurrency))
-        try XCTSkipIf(true)
-        #else
+    func test_AnyServiceDiscovery_async_subscribe() async throws {
         let configuration = InMemoryServiceDiscovery<Service, Instance>.Configuration(serviceInstances: [Self.fooService: Self.fooInstances])
         let serviceDiscovery = InMemoryServiceDiscovery(configuration: configuration)
         let anyServiceDiscovery = AnyServiceDiscovery(serviceDiscovery)
 
-        let semaphore = DispatchSemaphore(value: 0)
         let counter = ManagedAtomic<Int>(0)
 
-        Task.detached {
+        Task {
             // Allow time for subscription to start
             usleep(100_000)
             // Update #1
@@ -295,7 +268,7 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
             serviceDiscovery.register(Self.barService, instances: Self.barInstances)
         }
 
-        let task = Task.detached { () -> Void in
+        let task = Task { () in
             do {
                 for try await instances: [Instance] in anyServiceDiscovery.subscribeAndUnwrap(to: Self.barService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {
@@ -315,18 +288,15 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
                     guard let serviceDiscoveryError = error as? ServiceDiscoveryError, serviceDiscoveryError == .unavailable else {
                         return XCTFail("Expected ServiceDiscoveryError.unavailable, got \(error)")
                     }
-                    // Test is complete at this point
-                    semaphore.signal()
+                // Test is complete at this point
                 default:
                     XCTFail("Unexpected error \(error)")
                 }
             }
         }
 
-        _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(1))
-        task.cancel()
+        _ = await task.result
 
         XCTAssertEqual(counter.load(ordering: .relaxed), 2, "Expected to receive instances 2 times, got \(counter.load(ordering: .relaxed)) times")
-        #endif
     }
 }

--- a/Tests/ServiceDiscoveryTests/TypeErasedServiceDiscoveryTests.swift
+++ b/Tests/ServiceDiscoveryTests/TypeErasedServiceDiscoveryTests.swift
@@ -209,7 +209,7 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
             serviceDiscovery.register(Self.barService, instances: Self.barInstances)
         }
 
-        let task = Task { () in
+        let task = Task<Void, Error> { () in
             do {
                 for try await instances in boxedServiceDiscovery.subscribe(to: Self.barService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {
@@ -268,7 +268,7 @@ class TypeErasedServiceDiscoveryTests: XCTestCase {
             serviceDiscovery.register(Self.barService, instances: Self.barInstances)
         }
 
-        let task = Task { () in
+        let task = Task<Void, Error> { () in
             do {
                 for try await instances: [Instance] in anyServiceDiscovery.subscribeAndUnwrap(to: Self.barService) {
                     switch counter.wrappingIncrementThenLoad(ordering: .relaxed) {

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the SwiftServiceDiscovery open source project
 ##
-## Copyright (c) 2020-2023 Apple Inc. and the SwiftServiceDiscovery project authors
+## Copyright (c) 2020-2024 Apple Inc. and the SwiftServiceDiscovery project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][901]-202[0123]/YEARS/' -e 's/2019/YEARS/' -e 's/202[0123]/YEARS/'
+    sed -e 's/20[12][90123]-202[01234]/YEARS/' -e 's/2019/YEARS/' -e 's/202[01234]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "


### PR DESCRIPTION
- Remove all >= Swift 5.5 checks in tests since project requires 5.6 now
- Wait for taskGroup.isCancelled to become true in hope to reduce flakiness (resolves https://github.com/apple/swift-service-discovery/issues/53)