### PR TITLE
Restore public api for InMemoryServiceDiscovery.Configuration

### DIFF
--- a/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
+++ b/Sources/ServiceDiscovery/InMemoryServiceDiscovery.swift
@@ -188,23 +188,27 @@ private struct UncheckedSendableBox<T>: @unchecked Sendable {
     var value: T { _value }
 }
 
-public extension InMemoryServiceDiscovery {
-    struct Configuration: Sendable {
+extension InMemoryServiceDiscovery {
+    /// Configuration for ``InMemoryServiceDiscovery```
+    public struct Configuration: Sendable {
         /// Default configuration
-        static var `default`: Configuration { .init() }
+        public static var `default`: Configuration { .init() }
 
         /// Lookup timeout in case `deadline` is not specified
-        var defaultLookupTimeout: DispatchTimeInterval = .milliseconds(100)
+        public var defaultLookupTimeout: DispatchTimeInterval = .milliseconds(100)
 
         internal var serviceInstances: [Service: [Instance]]
 
-        init() { self.init(serviceInstances: [:]) }
+        /// Create an instance of ``InMemoryServiceDiscovery/Configuration``
+        public init() { self.init(serviceInstances: [:]) }
 
         /// Initializes `InMemoryServiceDiscovery` with the given service to instances mappings.
-        init(serviceInstances: [Service: [Instance]]) { self.serviceInstances = serviceInstances }
+        public init(serviceInstances: [Service: [Instance]]) { self.serviceInstances = serviceInstances }
 
         /// Registers `service` and its `instances`.
-        mutating func register(service: Service, instances: [Instance]) { self.serviceInstances[service] = instances }
+        public mutating func register(service: Service, instances: [Instance]) {
+            self.serviceInstances[service] = instances
+        }
     }
 }
 


### PR DESCRIPTION
PR https://github.com/apple/swift-service-discovery/pull/67 accidentally removed public API

This PR restores it, and makes it clearer, by avoiding `public extension`


Prior to this PR, it's impossible to create an instance of `InMemoryServiceDiscovery` because it requires a `Configuration`, which is impossible to construct since the init is internal, and so is the `.default`

